### PR TITLE
ADAPT-2948 Add asset url

### DIFF
--- a/src/components/partials/htmlHead.js
+++ b/src/components/partials/htmlHead.js
@@ -92,7 +92,11 @@ const HtmlHead = () => (
       type="text/javascript"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossOrigin="true"
+    />
     <link
       href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"

--- a/src/components/simple/linkList.js
+++ b/src/components/simple/linkList.js
@@ -1,23 +1,9 @@
 import React from "react";
 import { Heading } from "decanter-react";
-import Icon from "react-hero-icon";
-import SbLink from "../../utilities/sbLink";
 import CreateBloks from "../../utilities/createBloks";
 
-const iconClasses = "su-h-1em su-w-1em su-ml-04em su--mt-2 ";
-
 const LinkList = ({
-  blok: {
-    title,
-    headingLevel,
-    headingSize,
-    headingColor,
-    headingFont,
-    links,
-    linkSize,
-    linkColor,
-    linkStyle,
-  },
+  blok: { title, headingLevel, headingSize, headingColor, headingFont, links },
 }) => (
   <div>
     <Heading

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -11,6 +11,7 @@ import { Heading } from "decanter-react";
 import { dcnb } from "cnbuilder";
 import Link from "gatsby-link";
 import CardImage from "../components/media/cardImage";
+import { config } from "./config";
 
 const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
   let textColor = "su-text-current";
@@ -45,8 +46,20 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
 
         if (linktype === "asset") {
           // Asset links: map to <a>
+          // Rewrite the URL to the redirect link to mask the API endpoint.
+          let linkUrl = href;
+          if (config.isNetlify) {
+            linkUrl = linkUrl.replace(
+              /http?(s):\/\/a\.storyblok\.com/gi,
+              `${config.assetCdn}a`
+            );
+            linkUrl = linkUrl.replace(
+              /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
+              `${config.assetCdn}i`
+            );
+          }
           return (
-            <a href={href} target={target} className={linkColor}>
+            <a href={linkUrl} target={target} className={linkColor}>
               {children}
             </a>
           );

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -112,13 +112,13 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
       },
       [NODE_IMAGE]: (children, { src, alt }) => {
         // Rewrite the URL to the redirect link to mask the API endpoint.
-        let srcUrl = "";
+        let srcUrl = src;
         if (config.isNetlify) {
-          // srcUrl = src.replace(
-          //   /http?(s)\:\/\/a\.storyblok\.com/gi,
-          //   config.assetCdn + "a"
-          // );
-          srcUrl = src.replace(
+          srcUrl = srcUrl.replace(
+            /http?(s)\:\/\/a\.storyblok\.com/gi,
+            config.assetCdn + "a"
+          );
+          srcUrl = srcUrl.replace(
             /http?(s)\:\/\/img?[0-9]\.storyblok\.com/gi,
             config.assetCdn + "i"
           );

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -22,7 +22,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     linkColor = "su-text-digital-red-xlight hocus:su-text-white";
   }
 
-  let rendered = render(wysiwyg, {
+  const rendered = render(wysiwyg, {
     markResolvers: {
       [MARK_BOLD]: (children) => <strong>{children}</strong>,
       [MARK_ITALIC]: (children) => <em>{children}</em>,
@@ -112,15 +112,15 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
       },
       [NODE_IMAGE]: (children, { src, alt }) => {
         // Rewrite the URL to the redirect link to mask the API endpoint.
-        let srcUrl = src;
+        let srcUrl = { ...src };
         if (config.isNetlify) {
           srcUrl = srcUrl.replace(
-            /http?(s)\:\/\/a\.storyblok\.com/gi,
-            config.assetCdn + "a"
+            /http?(s)\\:\/\/a\.storyblok\.com/gi,
+            `${config.assetCdn}a`
           );
           srcUrl = srcUrl.replace(
-            /http?(s)\:\/\/img?[0-9]\.storyblok\.com/gi,
-            config.assetCdn + "i"
+            /http?(s)\\:\/\/img?[0-9]\.storyblok\.com/gi,
+            `${config.assetCdn}i`
           );
         }
 

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -112,13 +112,13 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
       },
       [NODE_IMAGE]: (children, { src, alt }) => {
         // Rewrite the URL to the redirect link to mask the API endpoint.
-        let srcUrl = src;
+        let srcUrl = "";
         if (config.isNetlify) {
-          srcUrl = srcUrl.replace(
-            /http?(s)\:\/\/a\.storyblok\.com/gi,
-            config.assetCdn + "a"
-          );
-          srcUrl = srcUrl.replace(
+          // srcUrl = src.replace(
+          //   /http?(s)\:\/\/a\.storyblok\.com/gi,
+          //   config.assetCdn + "a"
+          // );
+          srcUrl = src.replace(
             /http?(s)\:\/\/img?[0-9]\.storyblok\.com/gi,
             config.assetCdn + "i"
           );

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -120,11 +120,11 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
             `${config.assetCdn}a`
           );
 
-          console.log(`Before second: ${srcUrl}`);
-          srcUrl = srcUrl.replace(
-            /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
-            `${config.assetCdn}i`
-          );
+          // console.log(`Before second: ${srcUrl}`);
+          // srcUrl = srcUrl.replace(
+          //   /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
+          //   `${config.assetCdn}i`
+          // );
 
           console.log(`Results: ${srcUrl}`);
 

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -115,11 +115,11 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
         let srcUrl = src;
         if (config.isNetlify) {
           srcUrl = srcUrl.replace(
-            /http?(s)\\:\/\/a\.storyblok\.com/gi,
+            /http?(s):\/\/a\.storyblok\.com/gi,
             `${config.assetCdn}a`
           );
           srcUrl = srcUrl.replace(
-            /http?(s)\\:\/\/img?[0-9]\.storyblok\.com/gi,
+            /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
             `${config.assetCdn}i`
           );
         }

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -22,7 +22,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     linkColor = "su-text-digital-red-xlight hocus:su-text-white";
   }
 
-  const rendered = render(wysiwyg, {
+  let rendered = render(wysiwyg, {
     markResolvers: {
       [MARK_BOLD]: (children) => <strong>{children}</strong>,
       [MARK_ITALIC]: (children) => <em>{children}</em>,
@@ -110,48 +110,24 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
 
         return null;
       },
-      [NODE_IMAGE]: (children, { src, alt }) => {
-        // Rewrite the URL to the redirect link to mask the API endpoint.
-        let srcUrl = src;
-        if (config.isNetlify) {
-          console.log(`Before initial: ${srcUrl}`);
-          srcUrl = srcUrl.replace(
-            /http?(s):\/\/a\.storyblok\.com/gi,
-            `${config.assetCdn}a`
-          );
-
-          // console.log(`Before second: ${srcUrl}`);
-          // srcUrl = srcUrl.replace(
-          //   /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
-          //   `${config.assetCdn}i`
-          // );
-
-          console.log(`Results: ${srcUrl}`);
-
-          return (
-            <CardImage
-              size="horizontal"
-              filename={srcUrl}
-              alt={alt}
-              loading="lazy"
-            />
-          );
-        }
-
-        console.log(`Original Url: ${src}`);
-
-        return (
-          <CardImage
-            size="horizontal"
-            filename={src}
-            alt={alt}
-            loading="lazy"
-          />
-        );
-      },
+      [NODE_IMAGE]: (children, { src, alt }) => (
+        <CardImage size="horizontal" filename={src} alt={alt} loading="lazy" />
+      ),
     },
     defaultStringResolver: (str) => <p>{str}</p>,
   });
+
+  // Rewrite the URL to the redirect link to mask the API endpoint.
+  if (config.isNetlify) {
+    rendered = rendered.replace(
+      /http?(s):\/\/a\.storyblok\.com/gi,
+      `${config.assetCdn}a`
+    );
+    rendered = rendered.replace(
+      /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
+      `${config.assetCdn}i`
+    );
+  }
 
   return (
     <div className={dcnb("su-wysiwyg", textColor, className)}>{rendered}</div>

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -138,10 +138,12 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
           );
         }
 
+        console.log(`Original Url: ${src}`);
+
         return (
           <CardImage
             size="horizontal"
-            filename={srcUrl}
+            filename={src}
             alt={alt}
             loading="lazy"
           />

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -21,6 +21,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     textColor = "su-text-black-20";
     linkColor = "su-text-digital-red-xlight hocus:su-text-white";
   }
+
   let rendered = render(wysiwyg, {
     markResolvers: {
       [MARK_BOLD]: (children) => <strong>{children}</strong>,
@@ -109,24 +110,32 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
 
         return null;
       },
-      [NODE_IMAGE]: (children, { src, alt }) => (
-        <CardImage size="horizontal" filename={src} alt={alt} loading="lazy" />
-      ),
+      [NODE_IMAGE]: (children, { src, alt }) => {
+        // Rewrite the URL to the redirect link to mask the API endpoint.
+        let srcUrl = src;
+        if (config.isNetlify) {
+          srcUrl = srcUrl.replace(
+            /http?(s)\:\/\/a\.storyblok\.com/gi,
+            config.assetCdn + "a"
+          );
+          srcUrl = srcUrl.replace(
+            /http?(s)\:\/\/img?[0-9]\.storyblok\.com/gi,
+            config.assetCdn + "i"
+          );
+        }
+
+        return (
+          <CardImage
+            size="horizontal"
+            filename={srcUrl}
+            alt={alt}
+            loading="lazy"
+          />
+        );
+      },
     },
     defaultStringResolver: (str) => <p>{str}</p>,
   });
-
-  // Rewrite the URL to the redirect link to mask the API endpoint.
-  if (config.isNetlify) {
-    rendered = rendered.replace(
-      /http?(s)\:\/\/a\.storyblok\.com/gi,
-      config.assetCdn + "a"
-    );
-    rendered = rendered.replace(
-      /http?(s)\:\/\/img?[0-9]\.storyblok\.com/gi,
-      config.assetCdn + "i"
-    );
-  }
 
   return (
     <div className={dcnb("su-wysiwyg", textColor, className)}>{rendered}</div>

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -11,7 +11,6 @@ import { Heading } from "decanter-react";
 import { dcnb } from "cnbuilder";
 import Link from "gatsby-link";
 import CardImage from "../components/media/cardImage";
-import { config } from "./config";
 
 const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
   let textColor = "su-text-current";
@@ -116,18 +115,6 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     },
     defaultStringResolver: (str) => <p>{str}</p>,
   });
-
-  // Rewrite the URL to the redirect link to mask the API endpoint.
-  if (config.isNetlify) {
-    rendered = rendered.replace(
-      /http?(s):\/\/a\.storyblok\.com/gi,
-      `${config.assetCdn}a`
-    );
-    rendered = rendered.replace(
-      /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
-      `${config.assetCdn}i`
-    );
-  }
 
   return (
     <div className={dcnb("su-wysiwyg", textColor, className)}>{rendered}</div>

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -127,6 +127,15 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
           );
 
           console.log(`Results: ${srcUrl}`);
+
+          return (
+            <CardImage
+              size="horizontal"
+              filename={srcUrl}
+              alt={alt}
+              loading="lazy"
+            />
+          );
         }
 
         return (

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -112,7 +112,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
       },
       [NODE_IMAGE]: (children, { src, alt }) => {
         // Rewrite the URL to the redirect link to mask the API endpoint.
-        let srcUrl = { ...src };
+        let srcUrl = src;
         if (config.isNetlify) {
           srcUrl = srcUrl.replace(
             /http?(s)\\:\/\/a\.storyblok\.com/gi,

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -11,6 +11,7 @@ import { Heading } from "decanter-react";
 import { dcnb } from "cnbuilder";
 import Link from "gatsby-link";
 import CardImage from "../components/media/cardImage";
+import { config } from "./config";
 
 const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
   let textColor = "su-text-current";
@@ -20,7 +21,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     textColor = "su-text-black-20";
     linkColor = "su-text-digital-red-xlight hocus:su-text-white";
   }
-  const rendered = render(wysiwyg, {
+  let rendered = render(wysiwyg, {
     markResolvers: {
       [MARK_BOLD]: (children) => <strong>{children}</strong>,
       [MARK_ITALIC]: (children) => <em>{children}</em>,
@@ -114,6 +115,18 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     },
     defaultStringResolver: (str) => <p>{str}</p>,
   });
+
+  // Rewrite the URL to the redirect link to mask the API endpoint.
+  if (config.isNetlify) {
+    rendered = rendered.replace(
+      /http?(s)\:\/\/a\.storyblok\.com/gi,
+      config.assetCdn + "a"
+    );
+    rendered = rendered.replace(
+      /http?(s)\:\/\/img?[0-9]\.storyblok\.com/gi,
+      config.assetCdn + "i"
+    );
+  }
 
   return (
     <div className={dcnb("su-wysiwyg", textColor, className)}>{rendered}</div>

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -114,14 +114,19 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
         // Rewrite the URL to the redirect link to mask the API endpoint.
         let srcUrl = src;
         if (config.isNetlify) {
+          console.log(`Before initial: ${srcUrl}`);
           srcUrl = srcUrl.replace(
             /http?(s):\/\/a\.storyblok\.com/gi,
             `${config.assetCdn}a`
           );
+
+          console.log(`Before second: ${srcUrl}`);
           srcUrl = srcUrl.replace(
             /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
             `${config.assetCdn}i`
           );
+
+          console.log(`Results: ${srcUrl}`);
         }
 
         return (

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -20,8 +20,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className }) => {
     textColor = "su-text-black-20";
     linkColor = "su-text-digital-red-xlight hocus:su-text-white";
   }
-
-  let rendered = render(wysiwyg, {
+  const rendered = render(wysiwyg, {
     markResolvers: {
       [MARK_BOLD]: (children) => <strong>{children}</strong>,
       [MARK_ITALIC]: (children) => <em>{children}</em>,

--- a/src/utilities/sbLink.js
+++ b/src/utilities/sbLink.js
@@ -3,7 +3,8 @@ import { useLocation } from "@reach/router";
 import { parse } from "query-string";
 import Link from "gatsby-link";
 import { dcnb } from "cnbuilder";
-import { assetURL, isNetlify } from "../contexts/GlobalContext";
+import { isNetlify } from "../contexts/GlobalContext";
+import { config } from "./config";
 import HeroIcon from "../components/simple/heroIcon";
 
 /**
@@ -110,11 +111,11 @@ const SbLink = React.forwardRef((props, ref) => {
     if (isNetlify) {
       linkUrl = linkUrl.replace(
         /http?(s):\/\/a\.storyblok\.com/gi,
-        `${assetURL}a`
+        `${config.assetCdn}a`
       );
       linkUrl = linkUrl.replace(
         /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
-        `${assetURL}i`
+        `${config.assetCdn}i`
       );
     }
 

--- a/src/utilities/sbLink.js
+++ b/src/utilities/sbLink.js
@@ -5,6 +5,7 @@ import Link from "gatsby-link";
 import { ArrowUpIcon } from "@heroicons/react/outline";
 import { dcnb } from "cnbuilder";
 import { assetURL, isNetlify } from "../contexts/GlobalContext";
+import { config } from "./config";
 
 /**
  * Reusable Storyblok Link component for various link types
@@ -106,16 +107,16 @@ const SbLink = React.forwardRef((props, ref) => {
 
   // A link to a file or other asset.
   // ---------------------------------------------------------------------------
-  if (props.link?.linktype === "asset") {
+  if (props.link.linktype === "asset") {
     // Rewrite the URL to the redirect link to mask the API endpoint.
     if (isNetlify) {
       linkUrl = linkUrl.replace(
         /http?(s):\/\/a\.storyblok\.com/gi,
-        `${assetURL}a`
+        `${config.assetCdn}a`
       );
       linkUrl = linkUrl.replace(
         /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
-        `${assetURL}i`
+        `${config.assetCdn}i`
       );
     }
 

--- a/src/utilities/sbLink.js
+++ b/src/utilities/sbLink.js
@@ -4,7 +4,6 @@ import { parse } from "query-string";
 import Link from "gatsby-link";
 import { dcnb } from "cnbuilder";
 import { assetURL, isNetlify } from "../contexts/GlobalContext";
-import { config } from "./config";
 import HeroIcon from "../components/simple/heroIcon";
 
 /**
@@ -106,16 +105,16 @@ const SbLink = React.forwardRef((props, ref) => {
 
   // A link to a file or other asset.
   // ---------------------------------------------------------------------------
-  if (props.link.linktype === "asset") {
+  if (props.link?.linktype === "asset") {
     // Rewrite the URL to the redirect link to mask the API endpoint.
     if (isNetlify) {
       linkUrl = linkUrl.replace(
         /http?(s):\/\/a\.storyblok\.com/gi,
-        `${config.assetCdn}a`
+        `${assetURL}a`
       );
       linkUrl = linkUrl.replace(
         /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
-        `${config.assetCdn}i`
+        `${assetURL}i`
       );
     }
 

--- a/src/utilities/transformImage.js
+++ b/src/utilities/transformImage.js
@@ -3,6 +3,7 @@
 // https://www.storyblok.com/docs/image-service
 
 import { isNetlify, imageURL } from "../contexts/GlobalContext";
+import { config } from "./config";
 
 const transformImage = (image, param = "") => {
   const imageService = imageURL.endsWith("/") ? imageURL.slice(0, -1) : "";
@@ -27,7 +28,19 @@ const transformImage = (image, param = "") => {
     return imageService + path;
   }
 
-  return imageService + myParams + path;
+  // Rewrite the URL to the redirect link to mask the API endpoint.
+  let imageUrl = imageService + myParams + path;
+
+  imageUrl = imageUrl.replace(
+    /http?(s):\/\/a\.storyblok\.com/gi,
+    `${config.assetCdn}a`
+  );
+  imageUrl = imageUrl.replace(
+    /http?(s):\/\/img?[0-9]\.storyblok\.com/gi,
+    `${config.assetCdn}i`
+  );
+
+  return imageUrl;
 };
 
 export default transformImage;

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,5 @@
+# DYNAMIC REDIRECTS
+# ###############################################################################################
+/api/*   /.netlify/lambda/:splat   200
+/cdn/asset/*   https://assets.stanford.edu/a/:splat   301
+/cdn/img/*   https://assets.stanford.edu/i/:splat   301


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add asset url for PDFs and Images
- Note: File changes overlap with PR #68. I can manually resolve them once that PR is merged.

# Review By (Date)
- July 23

# Criticality
- 7

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Review locally at `/test/rebecca/asset-url-test/` or on [Netlify Preview](https://deploy-preview-75--stanford-alumni.netlify.app/test/rebecca/asset-url-test/)
- All asset URLs (i.e. pdfs, images, etc) should now be using `https://assets.stanford.edu/`
- This should work within the WYSIWYG, CtaLinks, and any other components that utilize the asset link/image field.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Associated Issues and/or People
- [ADAPT-2948](https://stanfordits.atlassian.net/browse/ADAPT-2948)