### PR TITLE
Update htmlHead.js

### DIFF
--- a/src/components/partials/htmlHead.js
+++ b/src/components/partials/htmlHead.js
@@ -92,7 +92,7 @@ const HtmlHead = () => (
       type="text/javascript"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
     <link
       href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
# READY FOR REVIEW

Fixes build error/warning

```
error Warning: Received `true` for a non-boolean attribute `crossOrigin`.

If you want to write it to the DOM, pass a string instead: crossOrigin="true" or crossOrigin={value.toString()}.
    in link
    in Fragment
    in HtmlHead
    in head
    in html
    in HTML
```


