### PR TITLE
Delete _redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,0 @@
-# DYNAMIC REDIRECTS
-# ###############################################################################################
-/api/*   /.netlify/lambda/:splat   200
-/cdn/asset/*   https://assets.stanford.edu/a/:splat   301
-/cdn/img/*   https://assets.stanford.edu/i/:splat   301


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Delete redirects file.
- We don't need these here. The `/cdn` URLs are legacy for the first version of the asset masking and are not required for these sites.
