### PR TITLE
ADAPT-2673: Add Empty search message to the search page

### DIFF
--- a/src/components/page-types/searchPage.js
+++ b/src/components/page-types/searchPage.js
@@ -30,6 +30,7 @@ const SearchPage = (props) => {
   const [selectedFacets, setSelectedFacets] = useState({
     siteName: siteParam || [],
   });
+  const [showEmptyMessage, setShowEmptyMessage] = useState(false);
 
   const client = algoliasearch(
     process.env.GATSBY_ALGOLIA_APP_ID,
@@ -53,11 +54,20 @@ const SearchPage = (props) => {
   };
 
   // Submit handler for search input.
-  const submitSearchQuery = (queryText) => {
-    setPageParam(undefined);
-    setQueryParam(queryText || undefined);
-    setPage(0);
-    setQuery(queryText);
+  const submitSearchQuery = (queryText, action = "submit") => {
+    if (!queryText.length) {
+      if (action === "submit") {
+        setShowEmptyMessage(true);
+      } else {
+        setShowEmptyMessage(false);
+      }
+    } else {
+      setShowEmptyMessage(false);
+      setPageParam(undefined);
+      setQueryParam(queryText || undefined);
+      setPage(0);
+      setQuery(queryText);
+    }
   };
 
   // Update page parameter when pager link is selected.
@@ -136,12 +146,15 @@ const SearchPage = (props) => {
           width="site"
           className="su-py-45 su-max-w-full md:su-py-80 "
         >
+
+          {showEmptyMessage && <p className="su-text-center">{blok.emptySearchMessage}</p>}
+
           <FlexBox gap justifyContent="center">
             <FlexCell xs="full" lg={results.facets ? 6 : 8}>
               <SearchField
                 onInput={(queryText) => updateAutocomplete(queryText)}
                 onSubmit={(queryText) => submitSearchQuery(queryText)}
-                onReset={() => submitSearchQuery("")}
+                onReset={() => submitSearchQuery("", "reset")}
                 defaultValue={query}
                 autocompleteSuggestions={suggestions}
                 clearBtnClasses={clearBtnClasses}

--- a/src/components/page-types/searchPage.js
+++ b/src/components/page-types/searchPage.js
@@ -146,8 +146,9 @@ const SearchPage = (props) => {
           width="site"
           className="su-py-45 su-max-w-full md:su-py-80 "
         >
-
-          {showEmptyMessage && <p className="su-text-center">{blok.emptySearchMessage}</p>}
+          {showEmptyMessage && (
+            <p className="su-text-center">{blok.emptySearchMessage}</p>
+          )}
 
           <FlexBox gap justifyContent="center">
             <FlexCell xs="full" lg={results.facets ? 6 : 8}>


### PR DESCRIPTION
# Summary
- Added a helper text for when the search input in submitted empty.

# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- 1

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to /search/
2. Check out the functionality on the search modal

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
