### PR TITLE
ADAPT-3115: Refactored facets implementation to allow for multiple values.

### DIFF
--- a/src/components/page-types/searchPage.js
+++ b/src/components/page-types/searchPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useImperativeHandle } from "react";
 import SbEditable from "storyblok-react";
 import algoliasearch from "algoliasearch";
 import { Container, FlexCell, FlexBox, Heading } from "decanter-react";
@@ -28,6 +28,8 @@ const SearchPage = (props) => {
   const [fileTypeParam, setFileTypeParam] = useQueryParam("type", ArrayParam);
   const [query, setQuery] = useState(queryParam || "");
   const [page, setPage] = useState(pageParam || 0);
+  const [siteNameValues, setSiteNameValues] = useState(null);
+  const [fileTypeValues, setFileTypeValues] = useState(null);
   const [selectedFacets, setSelectedFacets] = useState({
     siteName: siteParam || [],
     fileType: fileTypeParam || [],
@@ -105,15 +107,62 @@ const SearchPage = (props) => {
       selectedFacets[attribute].map((value) => `${attribute}:${value}`)
     );
 
-    index
-      .search(query, {
-        hitsPerPage,
-        page,
-        facets: ["domain", "siteName", "fileType"],
-        facetFilters,
-      })
+    const siteNameFilters = [];
+    Object.keys(selectedFacets).forEach((attribute) => {
+      if (attribute !== "siteName") {
+        const filters = selectedFacets[attribute].map(
+          (value) => `${attribute}:${value}`
+        );
+        siteNameFilters.push(filters);
+      }
+    });
+
+    const fileTypeFilters = [];
+    Object.keys(selectedFacets).forEach((attribute) => {
+      if (attribute !== "fileType") {
+        const filters = selectedFacets[attribute].map(
+          (value) => `${attribute}:${value}`
+        );
+        fileTypeFilters.push(filters);
+      }
+    });
+
+    client
+      .multipleQueries([
+        // Query for search results.
+        {
+          indexName: "crawler_federated-search",
+          query,
+          params: {
+            hitsPerPage,
+            page,
+            facets: ["siteName", "fileType"],
+            facetFilters,
+          },
+        },
+        // Disjunctive query for siteName facet values.
+        {
+          indexName: "crawler_federated-search",
+          query,
+          params: {
+            facets: ["siteName", "fileType"],
+            facetFilters: siteNameFilters,
+          },
+        },
+        // Disjunctive query for fileType facet values.
+        {
+          indexName: "crawler_federated-search",
+          query,
+          params: {
+            facets: ["siteName", "fileType"],
+            facetFilters: fileTypeFilters,
+          },
+        },
+      ])
       .then((queryResults) => {
-        setResults(queryResults);
+        setResults(queryResults.results[0]);
+        setSiteNameValues(queryResults.results[1].facets.siteName);
+        setFileTypeValues(queryResults.results[2].facets.fileType);
       });
   };
 
@@ -193,21 +242,21 @@ const SearchPage = (props) => {
           >
             {results.facets && (
               <FlexCell xs="full" lg={3} className="su-mb-[4rem] ">
-                {results.facets.siteName && (
+                {siteNameValues && (
                   <SearchFacet
                     label="Sites"
                     attribute="siteName"
-                    facetValues={results.facets.siteName}
+                    facetValues={siteNameValues}
                     selectedOptions={selectedFacets.siteName}
                     onChange={(values) => updateSiteFacet(values)}
                     exclude={["YouTube", "SoundCloud", "Apple Podcasts"]}
                   />
                 )}
-                {results.facets.fileType && (
+                {fileTypeValues && (
                   <SearchFacet
                     label="Media"
                     attribute="fileType"
-                    facetValues={results.facets.fileType}
+                    facetValues={fileTypeValues}
                     selectedOptions={selectedFacets.fileType}
                     onChange={(values) => updateFileTypeFacet(values)}
                     optionClasses="su-capitalize"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Refactors implementation of Search facets to allow for selecting multiple values.
- This may also fix ADAPT-3116

# Review By (Date)
- By end of next week (August 13th). 

# Criticality
- How critical is this PR on a 1-10 scale? 
Probably around a 7-8. 

# Review Tasks

## Setup tasks and/or behavior to test

1. Just visit /search in the preview environment, and test out the new filter behaviors.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ADAPT-3115
- https://stanfordits.atlassian.net/browse/ADAPT-3116


# Notes on Implementation
The primary challenge is that after you update the search filters, the updated response from Algolia will remove all of the facet values except for the ones you selected. 
However, Algolia does show the multiple-select behavior in some of their demos, so I was able to do a little bit of reverse engineering to see how this was implemented.
It looks like for "disjunctive facets', which is the name they use for this behavior, they run multiple queries. One for the main search results, plus separate queries for each disjunctive facet.

When you use their Instant Search widgets, it does all of this for you under the hood. But you have to implement this yourself when using the API directly. 
