### PR TITLE
ADAPT-3103: Updated unique ID for embed cards, to avoid error.

### DIFF
--- a/src/components/cards/embedCard.js
+++ b/src/components/cards/embedCard.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable react/no-danger */
@@ -14,13 +15,12 @@
 import React, { useEffect, useRef, useState } from "react";
 import SbEditable from "storyblok-react";
 import postscribe from "postscribe";
-import nextId from "react-id-generator";
 import Loader from "react-loader-spinner";
 import "react-loader-spinner/dist/loader/css/react-spinner-loader.css";
 
 const EmbedCard = ({ blok: { embed: html }, blok }) => {
   const myEmbed = useRef(null);
-  const uniqueId = nextId("su-alumni-");
+  const uniqueId = `su-alumni-${blok._uid}`;
   const [scriptLoaded, setScriptLoaded] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes render-breaking error on builds when using Embed Card component.

# Review By (Date)
- By end of sprint.

# Criticality
- 9/10 - Without this fix, white screen of death is seen when using embed card component.

# Review Tasks

## Setup tasks and/or behavior to test

1. Visit a page that is using the Embed Card component, such as /test/yvonne/test-home-embed-error/

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ADAPT-3103

# Notes
- The issue had something to do with the ID generator library not behaving as expected on static builds.
(I wasn't able to pin it down 100%, but I think what was happening was that it was re-generating the ID during hydration causing a mismatch with what was in the initial server-side render. )
- Moving away from the dynamically-generated ID to a static ID based on the Storyblok UUID resolved the issue.
- I tried duplicating a card to ensure this would not introduce issues with duplicate IDs. It looks like Storyblok creates a new UUID for each instance, so this shouldn't be an issue. 

