### PR TITLE
ADAPT-3106: Make noindex and canonical tags mutually exclusive.

### DIFF
--- a/src/components/page-types/basicPage.js
+++ b/src/components/page-types/basicPage.js
@@ -1,7 +1,6 @@
 import React from "react";
 import SbEditable from "storyblok-react";
 import { Container, Heading } from "decanter-react";
-import { Helmet } from "react-helmet";
 import Layout from "../partials/layout";
 import CreateBloks from "../../utilities/createBloks";
 import getNumBloks from "../../utilities/getNumBloks";
@@ -21,7 +20,6 @@ const BasicPage = (props) => {
       belowContent,
       ankleContent,
       sectionMenu,
-      noIndex,
     },
     blok,
   } = props;
@@ -40,7 +38,6 @@ const BasicPage = (props) => {
 
   return (
     <SbEditable content={blok}>
-      <Helmet>{noIndex && <meta name="robots" content="noindex" />}</Helmet>
       <Layout hasHero={numHero > 0} {...props}>
         <Container
           element="main"

--- a/src/components/partials/seo.js
+++ b/src/components/partials/seo.js
@@ -76,8 +76,8 @@ const Seo = ({ location, blok: { title: theTitle, seo }, blok }) => {
   return (
     <SbEditable content={blok}>
       <Helmet titleTemplate={`%s | ${title}`} title={seoTitle}>
-        <link rel="canonical" href={canonicalUrl} />
-
+        {!blok.noIndex && <link rel="canonical" href={canonicalUrl} />}
+        {blok.noIndex && <meta name="robots" content="noindex" />}
         {seoDescription !== "" && (
           <meta name="description" content={seoDescription} />
         )}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes canonical metatag when noindex metatag is present.

# Review By (Date)
- Before end of sprint.

# Criticality
- 6/10
- Can have a negative impact on page SEO if not resolved.

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to /test/nathan/no-index-test
2. Validate that noindex tag is present, and that canonical metatag does not appear.
3. Go to another page, like the homepage. Validate that the canonical metatag still appears as expected. 

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ADAPT-3106

# Resources
- https://www.searchenginejournal.com/google-dont-mix-noindex-relcanonical/262607/
