### PR TITLE
ADAPT-3305: Added x-frame-options header.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,7 +25,7 @@
 [[headers]]
   for = "/editor"
   [headers.values]
-    X-Frame-Options = "ALLOW"
+    X-Frame-Options = "ALLOWALL"
 
 # REDIRECTS
 # ###############################################################################

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,11 @@
     Strict-Transport-Security = "max-age=2592000"
     Permissions-Policy = "vibrate=(), geolocation=(), midi=(), notifications=(), push=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=()"
     X-Robots-Tag = "noindex, nofollow"
+    X-Frame-Options = "DENY"
+[[headers]]
+  for = "/editor"
+  [headers.values]
+    X-Frame-Options = "ALLOW"
 
 # REDIRECTS
 # ###############################################################################


### PR DESCRIPTION
# READY FOR REVIEW
- Note that the ticket includes several other sites - this PR only provides a solution for saa_alumni.

# Summary
- Sets header preventing site from being embedded in iframes. (With the exception of the /editor page).

# Review By (Date)
- Before end of current sprint. 

# Criticality
- 6/10? This helps to improve site security and ensure site is not embedded by unauthorized actors. 

# Review Tasks

## Setup tasks and/or behavior to test
This can only be validated on Netlify.

1. Visit any page on the Netlify Preview site.
2. Open the browser dev tools, click the Network tab, and click the entry for the current page request.
3. Look for the "x-frame-options" header in the Response Headers, confirm it says "Deny".
4. As an additional validation step, you can also create an HTML file with an iframe embed in it: `<iframe src="https://deploy-preview-156--stanford-alumni.netlify.app/editor" />` The iframe should fail to load, and there should be a warning message in the console.
5. Finally, log into Storybook and edit any page. Select the "deploy-preview-156" option from the Preview URL options (I already added it to the list of Preview URLs), and validate that the editor preview loads correctly. 

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ADAPT-3305
- There will be additional PRs that resolve this issue for the other Gatsby projects.

# Resources
- Note that we cannot completely unset the header for /editor. So we instead use the "allow" value which isn't valid. This throws a warning in the console, but still allows the page to be iframed. See https://answers.netlify.com/t/remove-inherited-header-applied-by-splat-path-in-headers/26263/12 for a detailed explanation on why we cannot unset the header. 
