### PR TITLE
ADAPT-2770 | @mattanglin | Adds basic auth to the user-guide

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,10 @@
   for = "/editor"
   [headers.values]
     X-Frame-Options = "ALLOWALL"
+[[headers]]
+  for = "/user-guide/*"
+  [headers.values]
+    Basic-Auth = "saa:@lumn1@ss0c1@t10n"
 
 # REDIRECTS
 # ###############################################################################


### PR DESCRIPTION
# NOT READY FOR REVIEW (POC)

# Summary
- Adding basic auth headers to user-guide pages

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to 
3. Verify that the credentials are required and allow access to all /user-guide/* pages
