### PR TITLE
ADAPT-3258 | @mattanglin | trip page faculty section

### DIFF
--- a/src/components/page-types/TripPage/TripPage.jsx
+++ b/src/components/page-types/TripPage/TripPage.jsx
@@ -9,6 +9,7 @@ import * as styles from './TripPage.styles';
 
 import { TripPageHeroSection } from './TripPageHeroSection';
 import { TripPageOverviewSection } from './TripPageOverviewSection';
+import { TripPageFacultySection } from './TripPageFacultySection';
 
 export const TripPageProps = {
   blok: TripContent,
@@ -33,6 +34,10 @@ const TripPage = (props) => {
       inquireURL,
       reservationURL,
       overviewBelowContent,
+      // Faculty
+      facultyHeading,
+      facultyBody,
+      facultyBelowContent,
     } = {},
   } = props;
   const printContainerRef = useRef(null);
@@ -70,7 +75,12 @@ const TripPage = (props) => {
               overviewBelowContent={overviewBelowContent}
               onPrint={printTrip}
             />
-            {/* TODO: Faculty Section */}
+            {/* Faculty Section */}
+            <TripPageFacultySection
+              facultyHeading={facultyHeading}
+              facultyBody={facultyBody}
+              facultyBelowContent={facultyBelowContent}
+            />
             {/* TODO: Itinerary Section */}
             {/* TODO: Details Section */}
             {/* TODO: Related Trips */}

--- a/src/components/page-types/TripPage/TripPageFacultySection.jsx
+++ b/src/components/page-types/TripPage/TripPageFacultySection.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Container } from 'decanter-react';
+import CreateBloks from '../../../utilities/createBloks';
+import { SBBlokType } from '../../../types/storyblok/SBBlokType';
+import { SBRichTextType } from '../../../types/storyblok/SBRichTextType';
+import RichTextRenderer from '../../../utilities/richTextRenderer';
+import { TripPageSectionWrapper } from './TripPageSectionWrapper';
+import * as styles from './TripPageFacultySection.styles';
+
+export const TripPageFacultySectionProps = {
+  facultyHeading: PropTypes.string,
+  facultyBody: SBRichTextType,
+  facultyBelowContent: SBBlokType,
+};
+
+export const TripPageFacultySection = (props) => {
+  const { facultyHeading, facultyBody, facultyBelowContent } = props;
+
+  return (
+    <TripPageSectionWrapper heading="Faculty leaders">
+      <Container width="site" className={styles.main}>
+        <div className={styles.content}>
+          <h3 className={styles.heading}>{facultyHeading}</h3>
+          <RichTextRenderer wysiwyg={facultyBody} />
+        </div>
+      </Container>
+      {facultyBelowContent && facultyBelowContent.length > 0 && (
+        <div className="trip-page-faculty-below-content">
+          <CreateBloks blokSection={facultyBelowContent} />
+        </div>
+      )}
+    </TripPageSectionWrapper>
+  );
+};
+TripPageFacultySection.propTypes = TripPageFacultySectionProps;

--- a/src/components/page-types/TripPage/TripPageFacultySection.styles.js
+++ b/src/components/page-types/TripPage/TripPageFacultySection.styles.js
@@ -1,0 +1,4 @@
+export const main =
+  'su-grid md:su-grid-cols-4 su-grid-gap su-grid-cols-1 su-mb-45';
+export const content = 'md:su-col-span-2';
+export const heading = 'su-font-serif';

--- a/src/components/page-types/TripPage/TripPageOverviewSection.styles.js
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.styles.js
@@ -1,7 +1,5 @@
-export const root = '';
 export const main =
   'su-grid md:su-grid-cols-4 su-grid-gap su-grid-cols-1 su-mb-45';
-export const sectionHeading = '';
 export const content = 'md:su-col-span-2';
 export const heading = 'su-font-serif';
 export const summary =


### PR DESCRIPTION
# NOT READY FOR REVIEW
This PR is based off of #195 and thus it includes the changeset from that PR as well. This PR will be rebased once #195 has been merged into `dev`.

# Summary
- Trip Page Faculty Leaders Section

## Notes
- I added `basicCardHorizontal` for the faculty leader cards which needed to be added to components allow-list for the grid.
- There's an additional header component added with no content to create spacing between the faculty cards and the poster. Maybe we want to create a simple spacing component?
- I believe we'll need a new gradient overlay treatment for the poster component.

# Review By (Date)
- end of sprint

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to https://deploy-preview-196--stanford-alumni-uat.netlify.app/travel-study/trips/botswana-south-africa-and-zambia/#trip-faculty-leaders-section
3. Verify styling and display of faculty leaders section
