### PR TITLE
nojira | @mattanglin | these alerts are just wrong

### DIFF
--- a/src/components/composite/alert.js
+++ b/src/components/composite/alert.js
@@ -10,7 +10,7 @@ const Alert = ({
   blok,
 }) => {
   const hasCta = getNumBloks(alertCta) > 0;
-  const [isAlertDismissed, setIsAlertDismissed] = useState(true);
+  const [showAlert, setShowAlert] = useState(false);
   const isLinkDark = type === 'warning';
   let footerContent = '';
 
@@ -31,15 +31,13 @@ const Alert = ({
   }
 
   useEffect(() => {
-    // eslint-disable-next-line no-undef
-    const isDismissed = sessionStorage.getItem(_uid);
-    if (isDismissed) setIsAlertDismissed(false);
+    const dismissedInSession = sessionStorage.getItem(_uid);
+    if (!dismissedInSession) setShowAlert(true);
   }, [_uid]);
 
   const dismissHandler = () => {
-    // eslint-disable-next-line no-undef
     sessionStorage.setItem(_uid, 'dismissed');
-    setIsAlertDismissed(false);
+    setShowAlert(false);
   };
 
   const DismissBtn = (
@@ -57,7 +55,7 @@ const Alert = ({
     footerWrapper: 'su-rs-mt-1',
   };
 
-  if (!isAlertDismissed) return null;
+  if (!showAlert) return null;
 
   return (
     <SbEditable content={blok}>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Fix alert component to be hidden by default until locally stored dismissal checked to prevent server rendering

# Review By (Date)
- ASP
- 
# Review Tasks

## Setup tasks and/or behavior to test

1. Check that alerts only display on client (not in page source) when not already dismissed
