### PR TITLE
ADAPT-4208: Add 1 day to filter trip duration since we're doing inclusive # of days

### DIFF
--- a/src/utilities/filterTrips.js
+++ b/src/utilities/filterTrips.js
@@ -74,7 +74,7 @@ export const tripMatchesFilterType = (trip, filterType, filters = []) => {
   const { startDate, endDate } = trip.content;
   const tripYears = getTripYear(startDate);
   const tripMonths = getTripMonth(startDate);
-  const tripDurationDays = getDuration(startDate, endDate).days;
+  const tripDurationDays = getDuration(startDate, endDate).days + 1;
 
   switch (filterType) {
     case 'trip-region':
@@ -267,7 +267,7 @@ export const filterTrips = (allTrips, activeFilters = [], facetIndex) => {
  */
 export const getTripDurationFilters = (trip, durationFilters) => {
   const { startDate, endDate } = trip.content;
-  const duration = getDuration(startDate, endDate).days;
+  const duration = getDuration(startDate, endDate).days + 1;
 
   const matchingFilters = durationFilters.filter((filter) =>
     tripWithinDuration(duration, filter.value)


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Trip duration filter should calculate inclusive # of days, eg, if trip is from May 1-2, it should have a trip duration of 2 days and not 1 day.
https://stanfordits.atlassian.net/browse/ADAPT-4208

# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Review Tasks

## Setup tasks and/or behavior to test

1. GO to https://deploy-preview-265--stanford-alumni.netlify.app/travel-study/destinations/?page=1&trip-duration=15-
2. Check this trip that's from May 10 to 24, shows up under the "15+ days" duration filter, instead of the 10-14 days filter
![Screen Shot 2021-12-16 at 6 28 42 PM](https://user-images.githubusercontent.com/42749717/146479179-81891b1d-03ce-4a04-a945-5285c6e317ae.png)

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
