### PR TITLE
ADAPT-4414 | @rebeccahongsf | add single column layout option to form theme

### DIFF
--- a/src/components/composite/HeroImage/HeroImage.styles.js
+++ b/src/components/composite/HeroImage/HeroImage.styles.js
@@ -13,7 +13,7 @@ export const overlay = ({ overlay: overlayType }) =>
       'su-bg-gradient-to-b su-from-black-true-opacity-20':
         overlayType === 'dark',
       'su-bg-gradient-to-b su-from-transparent': overlayType === 'normal',
-      'su-bg-gradient-to-t lg:su-bg-gradient-to-l su-from-saa-black-opacity-40':
+      'su-bg-gradient-to-t lg:su-bg-gradient-to-l su-from-saa-black-opacity-0':
         overlayType === 'formDark',
     }
   );

--- a/src/components/embed/giveGabForm.js
+++ b/src/components/embed/giveGabForm.js
@@ -22,13 +22,16 @@ const GiveGabForm = ({
     uuid,
   },
   blok,
-  bgCardStyle,
+  bgCardStyle: bgCardProps,
 }) => {
   console.log('bgCardStyle:', bgCardStyle);
   const htmlId = uuid;
   const { isAuthenticating } = useContext(AuthContext);
   const preBlok = { markup: pre_markup };
   const postBlok = { markup: post_markup };
+  const bgCardStyle =
+    bgCardProps ||
+    'su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg';
 
   if (isAuthenticating) {
     return (
@@ -37,8 +40,7 @@ const GiveGabForm = ({
         aria-busy="true"
         className={dcnb(
           'su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6',
-          bgCardStyle ||
-            'su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm'
+          bgCardStyle
         )}
       >
         <ClipLoader color="#00BFFF" height={50} width={50} />
@@ -64,11 +66,7 @@ const GiveGabForm = ({
       )}
       <Container
         width="full"
-        className={dcnb(
-          'children:su-text-white',
-          bgCardStyle ||
-            'children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg'
-        )}
+        className={dcnb('children:su-text-white', bgCardStyle)}
       >
         <div className="form-gradient su-rs-p-5 md:su-rs-p-6 2xl:su-pb-[10.8rem]">
           <Embed blok={preBlok} />

--- a/src/components/embed/giveGabForm.js
+++ b/src/components/embed/giveGabForm.js
@@ -70,7 +70,7 @@ const GiveGabForm = ({
             'children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg'
         )}
       >
-        <div className="form-gradient su-rs-p-5 2xl:su-pb-[10.8rem]">
+        <div className="form-gradient su-rs-p-5 md:su-rs-p-6 2xl:su-pb-[10.8rem]">
           <Embed blok={preBlok} />
           <DynaScript src={url} id={htmlId} errorText={errorText} />
         </div>

--- a/src/components/embed/giveGabForm.js
+++ b/src/components/embed/giveGabForm.js
@@ -24,7 +24,6 @@ const GiveGabForm = ({
   blok,
   bgCardStyle: bgCardProps,
 }) => {
-  console.log('bgCardStyle:', bgCardStyle);
   const htmlId = uuid;
   const { isAuthenticating } = useContext(AuthContext);
   const preBlok = { markup: pre_markup };

--- a/src/components/embed/giveGabForm.js
+++ b/src/components/embed/giveGabForm.js
@@ -22,15 +22,12 @@ const GiveGabForm = ({
     uuid,
   },
   blok,
-  bgCardStyle: bgCardProps,
+  bgCardStyle,
 }) => {
   const htmlId = uuid;
   const { isAuthenticating } = useContext(AuthContext);
   const preBlok = { markup: pre_markup };
   const postBlok = { markup: post_markup };
-  const bgCardStyle =
-    bgCardProps ||
-    'su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg';
 
   if (isAuthenticating) {
     return (
@@ -38,7 +35,7 @@ const GiveGabForm = ({
         aria-live="polite"
         aria-busy="true"
         className={dcnb(
-          'su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6',
+          'su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6 su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm',
           bgCardStyle
         )}
       >
@@ -65,7 +62,10 @@ const GiveGabForm = ({
       )}
       <Container
         width="full"
-        className={dcnb('children:su-text-white', bgCardStyle)}
+        className={dcnb(
+          'children:su-text-white children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg',
+          bgCardStyle
+        )}
       >
         <div className="form-gradient su-rs-p-5 md:su-rs-p-6 2xl:su-pb-[10.8rem]">
           <Embed blok={preBlok} />

--- a/src/components/embed/giveGabForm.js
+++ b/src/components/embed/giveGabForm.js
@@ -36,7 +36,7 @@ const GiveGabForm = ({
         aria-live="polite"
         aria-busy="true"
         className={dcnb(
-          'su-shadow-lg su-text-white su-rs-p-5',
+          'su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6',
           bgCardStyle ||
             'su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm'
         )}
@@ -65,7 +65,7 @@ const GiveGabForm = ({
       <Container
         width="full"
         className={dcnb(
-          ' children:su-text-white',
+          'children:su-text-white',
           bgCardStyle ||
             'children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg'
         )}

--- a/src/components/embed/giveGabForm.js
+++ b/src/components/embed/giveGabForm.js
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import SbEditable from 'storyblok-react';
 import ClipLoader from 'react-spinners/ClipLoader';
+import { dcnb } from 'cnbuilder';
 import { Container } from '../layout/Container';
 import Embed from './embed';
 import DynaScript from './dynaScript';
@@ -21,7 +22,9 @@ const GiveGabForm = ({
     uuid,
   },
   blok,
+  bgCardStyle,
 }) => {
+  console.log('bgCardStyle:', bgCardStyle);
   const htmlId = uuid;
   const { isAuthenticating } = useContext(AuthContext);
   const preBlok = { markup: pre_markup };
@@ -32,7 +35,11 @@ const GiveGabForm = ({
       <div
         aria-live="polite"
         aria-busy="true"
-        className="su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm su-shadow-lg su-text-white su-rs-p-5"
+        className={dcnb(
+          'su-shadow-lg su-text-white su-rs-p-5',
+          bgCardStyle ||
+            'su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm'
+        )}
       >
         <ClipLoader color="#00BFFF" height={50} width={50} />
         <p>Loading form...</p>
@@ -57,7 +64,11 @@ const GiveGabForm = ({
       )}
       <Container
         width="full"
-        className="children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg children:su-text-white"
+        className={dcnb(
+          ' children:su-text-white',
+          bgCardStyle ||
+            'children:backdrop-opacity-30 children:su-bg-gradient-to-tl children:su-backdrop-blur-sm children:su-shadow-lg'
+        )}
       >
         <div className="form-gradient su-rs-p-5 2xl:su-pb-[10.8rem]">
           <Embed blok={preBlok} />

--- a/src/components/page-types/formPage/formPage.js
+++ b/src/components/page-types/formPage/formPage.js
@@ -75,7 +75,7 @@ const FormPage = (props) => {
                     font="serif"
                     srOnly={isSrOnlyTitle}
                     id="page-title"
-                    className="su-rs-mt-5"
+                    className={isSingleColumn ? 'su-rs-mt-5' : 'su-rs-mt-7'}
                   >
                     {title}
                   </Heading>

--- a/src/components/page-types/formPage/formPage.js
+++ b/src/components/page-types/formPage/formPage.js
@@ -29,7 +29,7 @@ const FormPage = (props) => {
   const numAnkle = getNumBloks(ankleContent);
   let contentStyle = 'su-sticky su-top-0 su-h-fit';
   let formCardStyle = 'su-rs-mt-5 lg:su-col-start-7 xl:su-col-start-7';
-  let bgCardStyle = '';
+  let bgCardStyle = false;
 
   if (isSingleColumn) {
     contentStyle = '';
@@ -89,7 +89,10 @@ const FormPage = (props) => {
               xl={isSingleColumn ? 6 : 5}
               className={formCardStyle}
             >
-              <CreateBloks blokSection={giveGabForm} props={bgCardStyle} />
+              <CreateBloks
+                blokSection={giveGabForm}
+                bgCardStyle={bgCardStyle}
+              />
             </GridCell>
           </Grid>
           {numAnkle > 0 && <Ankle isDark {...props} />}

--- a/src/components/page-types/formPage/formPage.js
+++ b/src/components/page-types/formPage/formPage.js
@@ -11,7 +11,6 @@ import { HeroImage } from '../../composite/HeroImage/HeroImage';
 import { Grid } from '../../layout/Grid';
 import { GridCell } from '../../layout/GridCell';
 import AuthenticatedPage from '../../auth/AuthenticatedPage';
-import { content } from '../TripPage/TripPageHeroSection.styles';
 
 const FormPage = (props) => {
   const {
@@ -27,14 +26,12 @@ const FormPage = (props) => {
     blok,
   } = props;
   const numAnkle = getNumBloks(ankleContent);
-  let fullWidth = false;
   let contentStyle = 'su-sticky su-top-0 su-h-fit';
   let formCardStyle = 'su-rs-mt-5 lg:su-col-start-7 xl:su-col-start-7';
 
   if (isSingleColumn) {
-    fullWidth = 12;
     contentStyle = '';
-    formCardStyle = '';
+    formCardStyle = 'lg:su-col-start-4 xl:su-col-start-4';
   }
 
   return (
@@ -62,7 +59,11 @@ const FormPage = (props) => {
             xs={12}
             className="su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6"
           >
-            <GridCell xs={12} lg={fullWidth || 5} xl={fullWidth || 5}>
+            <GridCell
+              xs={12}
+              lg={isSingleColumn ? 12 : 5}
+              xl={isSingleColumn ? 12 : 5}
+            >
               <div className={dcnb('su-text-white', contentStyle)}>
                 {title && (
                   <Heading
@@ -81,8 +82,8 @@ const FormPage = (props) => {
             </GridCell>
             <GridCell
               xs={12}
-              lg={fullWidth || 6}
-              xl={fullWidth || 5}
+              lg={6}
+              xl={isSingleColumn ? 6 : 5}
               className={formCardStyle}
             >
               <CreateBloks blokSection={giveGabForm} />

--- a/src/components/page-types/formPage/formPage.js
+++ b/src/components/page-types/formPage/formPage.js
@@ -38,68 +38,68 @@ const FormPage = (props) => {
   }
 
   return (
-    // <AuthenticatedPage>
-    <SbEditable content={blok}>
-      <Layout {...props}>
-        <Container
-          as="main"
-          id="main-content"
-          className="basic-page su-relative su-flex-grow su-w-full"
-          width="full"
-        >
-          <div className="su-fixed su-top-0 su-z-0 su-h-full su-w-full">
-            <HeroImage
-              filename={filename}
-              alt={alt}
-              focus={focus}
-              overlay="formDark"
-              aspectRatio="5x2"
-              className="su-object-cover su-h-full su-w-full"
-            />
-          </div>
-          <Grid
-            gap
-            xs={12}
-            className="su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6"
+    <AuthenticatedPage>
+      <SbEditable content={blok}>
+        <Layout {...props}>
+          <Container
+            as="main"
+            id="main-content"
+            className="basic-page su-relative su-flex-grow su-w-full"
+            width="full"
           >
-            <GridCell
-              xs={12}
-              lg={isSingleColumn ? 12 : 5}
-              xl={isSingleColumn ? 12 : 5}
-            >
-              <div className={dcnb('su-text-white', contentStyle)}>
-                {title && (
-                  <Heading
-                    level={1}
-                    align="left"
-                    font="serif"
-                    srOnly={isSrOnlyTitle}
-                    id="page-title"
-                    className={isSingleColumn ? 'su-rs-mt-5' : 'su-rs-mt-7'}
-                  >
-                    {title}
-                  </Heading>
-                )}
-                <CreateBloks blokSection={formContent} trip={trip} />
-              </div>
-            </GridCell>
-            <GridCell
-              xs={12}
-              lg={6}
-              xl={isSingleColumn ? 6 : 5}
-              className={formCardStyle}
-            >
-              <CreateBloks
-                blokSection={giveGabForm}
-                bgCardStyle={bgCardStyle}
+            <div className="su-fixed su-top-0 su-z-0 su-h-full su-w-full">
+              <HeroImage
+                filename={filename}
+                alt={alt}
+                focus={focus}
+                overlay="formDark"
+                aspectRatio="5x2"
+                className="su-object-cover su-h-full su-w-full"
               />
-            </GridCell>
-          </Grid>
-          {numAnkle > 0 && <Ankle isDark {...props} />}
-        </Container>
-      </Layout>
-    </SbEditable>
-    // </AuthenticatedPage>
+            </div>
+            <Grid
+              gap
+              xs={12}
+              className="su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6"
+            >
+              <GridCell
+                xs={12}
+                lg={isSingleColumn ? 12 : 5}
+                xl={isSingleColumn ? 12 : 5}
+              >
+                <div className={dcnb('su-text-white', contentStyle)}>
+                  {title && (
+                    <Heading
+                      level={1}
+                      align="left"
+                      font="serif"
+                      srOnly={isSrOnlyTitle}
+                      id="page-title"
+                      className={isSingleColumn ? 'su-rs-mt-5' : 'su-rs-mt-7'}
+                    >
+                      {title}
+                    </Heading>
+                  )}
+                  <CreateBloks blokSection={formContent} trip={trip} />
+                </div>
+              </GridCell>
+              <GridCell
+                xs={12}
+                lg={6}
+                xl={isSingleColumn ? 6 : 5}
+                className={formCardStyle}
+              >
+                <CreateBloks
+                  blokSection={giveGabForm}
+                  bgCardStyle={bgCardStyle}
+                />
+              </GridCell>
+            </Grid>
+            {numAnkle > 0 && <Ankle isDark {...props} />}
+          </Container>
+        </Layout>
+      </SbEditable>
+    </AuthenticatedPage>
   );
 };
 

--- a/src/components/page-types/formPage/formPage.js
+++ b/src/components/page-types/formPage/formPage.js
@@ -28,7 +28,7 @@ const FormPage = (props) => {
   } = props;
   const numAnkle = getNumBloks(ankleContent);
   let contentStyle = 'su-sticky su-top-0 su-h-fit';
-  let formCardStyle = 'su-rs-mt-5 lg:su-col-start-7 xl:su-col-start-7';
+  let formCardStyle = 'su-rs-mt-7 lg:su-col-start-7 xl:su-col-start-7';
   let bgCardStyle = false;
 
   if (isSingleColumn) {

--- a/src/components/page-types/formPage/formPage.js
+++ b/src/components/page-types/formPage/formPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SbEditable from 'storyblok-react';
+import { dcnb } from 'cnbuilder';
 import { Container } from '../../layout/Container';
 import { Heading } from '../../simple/Heading';
 import Layout from '../../partials/layout';
@@ -10,6 +11,7 @@ import { HeroImage } from '../../composite/HeroImage/HeroImage';
 import { Grid } from '../../layout/Grid';
 import { GridCell } from '../../layout/GridCell';
 import AuthenticatedPage from '../../auth/AuthenticatedPage';
+import { content } from '../TripPage/TripPageHeroSection.styles';
 
 const FormPage = (props) => {
   const {
@@ -20,67 +22,77 @@ const FormPage = (props) => {
       formContent,
       giveGabForm,
       ankleContent,
+      isSingleColumn,
     },
     blok,
   } = props;
   const numAnkle = getNumBloks(ankleContent);
+  let fullWidth = false;
+  let contentStyle = 'su-sticky su-top-0 su-h-fit';
+  let formCardStyle = 'su-rs-mt-5 lg:su-col-start-7 xl:su-col-start-7';
+
+  if (isSingleColumn) {
+    fullWidth = 12;
+    contentStyle = '';
+    formCardStyle = '';
+  }
 
   return (
-    <AuthenticatedPage>
-      <SbEditable content={blok}>
-        <Layout {...props}>
-          <Container
-            as="main"
-            id="main-content"
-            className="basic-page su-relative su-flex-grow su-w-full"
-            width="full"
+    // <AuthenticatedPage>
+    <SbEditable content={blok}>
+      <Layout {...props}>
+        <Container
+          as="main"
+          id="main-content"
+          className="basic-page su-relative su-flex-grow su-w-full"
+          width="full"
+        >
+          <div className="su-fixed su-top-0 su-z-0 su-h-full su-w-full">
+            <HeroImage
+              filename={filename}
+              alt={alt}
+              focus={focus}
+              overlay="formDark"
+              aspectRatio="5x2"
+              className="su-object-cover su-h-full su-w-full"
+            />
+          </div>
+          <Grid
+            gap
+            xs={12}
+            className="su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6"
           >
-            <div className="su-fixed su-top-0 su-z-0 su-h-full su-w-full">
-              <HeroImage
-                filename={filename}
-                alt={alt}
-                focus={focus}
-                overlay="formDark"
-                aspectRatio="5x2"
-                className="su-object-cover su-h-full su-w-full"
-              />
-            </div>
-            <Grid
-              gap
+            <GridCell xs={12} lg={fullWidth || 5} xl={fullWidth || 5}>
+              <div className={dcnb('su-text-white', contentStyle)}>
+                {title && (
+                  <Heading
+                    level={1}
+                    align="left"
+                    font="serif"
+                    srOnly={isSrOnlyTitle}
+                    id="page-title"
+                    className="su-rs-mt-5"
+                  >
+                    {title}
+                  </Heading>
+                )}
+                <CreateBloks blokSection={formContent} />
+              </div>
+            </GridCell>
+            <GridCell
               xs={12}
-              className="su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6"
+              lg={fullWidth || 6}
+              xl={fullWidth || 5}
+              className={formCardStyle}
             >
-              <GridCell xs={12} lg={5} xl={5}>
-                <div className="su-sticky su-top-0 su-h-fit su-text-white">
-                  {title && (
-                    <Heading
-                      level={1}
-                      align="left"
-                      font="serif"
-                      srOnly={isSrOnlyTitle}
-                      id="page-title"
-                      className="su-rs-mt-5"
-                    >
-                      {title}
-                    </Heading>
-                  )}
-                  <CreateBloks blokSection={formContent} />
-                </div>
-              </GridCell>
-              <GridCell
-                xs={12}
-                lg={6}
-                xl={5}
-                className="su-rs-mt-5 lg:su-col-start-7 xl:su-col-start-7"
-              >
-                <CreateBloks blokSection={giveGabForm} />
-              </GridCell>
-            </Grid>
-            {numAnkle > 0 && <Ankle isDark {...props} />}
-          </Container>
-        </Layout>
-      </SbEditable>
-    </AuthenticatedPage>
+              <CreateBloks blokSection={giveGabForm} />
+            </GridCell>
+          </Grid>
+          {numAnkle > 0 && <Ankle isDark {...props} />}
+        </Container>
+      </Layout>
+    </SbEditable>
+    // </AuthenticatedPage>
   );
 };
 

--- a/src/components/page-types/formPage/tripNotifyMe.js
+++ b/src/components/page-types/formPage/tripNotifyMe.js
@@ -83,6 +83,7 @@ const TripNotifyMe = (props) => {
         </GridCell>
         <GridCell
           xs={12}
+          sm={6}
           md={4}
           lg={12}
           className="md:su-col-start-8 lg:su-col-start-1 su-rs-mt-7 lg:su-mt-0"

--- a/src/components/page-types/formPage/tripNotifyMe.js
+++ b/src/components/page-types/formPage/tripNotifyMe.js
@@ -85,7 +85,7 @@ const TripNotifyMe = (props) => {
           xs={12}
           md={4}
           lg={12}
-          className="xs:su-col-start-8 lg:su-col-start-1"
+          className="md:su-col-start-8 lg:su-col-start-1 su-rs-mt-7 lg:su-mt-0"
         >
           <Grid xl={5} className={styles.summaryContent}>
             <GridCell xl={3} className={styles.summaryItem}>

--- a/src/tailwind/plugins/theme/colors.js
+++ b/src/tailwind/plugins/theme/colors.js
@@ -22,7 +22,7 @@ module.exports = function () {
       DEFAULT: '#181D1C',
       dark: '#070B0A',
       opacity: {
-        40: 'rgba(24, 29, 28, 0.4)',
+        0: 'rgba(24, 29, 28, 0)',
         80: 'rgba(24, 29, 28, 0.8)',
       },
     },


### PR DESCRIPTION
# READY FOR REVIEW
- Tagging @sherakama for retro review 😄 

# Summary
- add single column layout option to form theme 
- make form adjustments outlined in ADAPT-4927
- fixup responsive styling

# Review By (Date)
- End of Sprint Q (retro review)

# Review Tasks

## Setup tasks and/or behavior to test

1. Login as `zguan`
2. Review the designs of the following pages
- [`/travel-study/italy-notify-me-form/`](https://deploy-preview-337--stanford-alumni.netlify.app/travel-study/italy-notify-me-form/)
- [`/travel-study/additional-payment-form`](https://deploy-preview-337--stanford-alumni.netlify.app/travel-study/additional-payment-form/)
- [`/travel-study/custom-journeys-form`](https://deploy-preview-337--stanford-alumni.netlify.app/travel-study/custom-journeys-form/)
Refer to [Drea's blue text notes and form page skin section.](https://www.figma.com/file/ZzuzKL805DOjPyT31ICc0c/Travel-Study-Microsite?node-id=4326%3A48697)

# Associated Issues and/or People
- ADAPT-4414