### PR TITLE
Support Mulesoft and Keycloak oauth providers for FullGG

### DIFF
--- a/src/api/auth/profile.js
+++ b/src/api/auth/profile.js
@@ -13,7 +13,7 @@ import { tokenFetcher, profileFetcher } from '../../utilities/getGgProfile';
  */
 const megaprofileHandler = async (req, res) => {
   const mp = new MegaProfile();
-  const profileId = 123 || req.user.encodedSUID;
+  const profileId = req.user.encodedSUID;
   const token = await tokenFetcher();
   let fullgg;
   let affiliations;

--- a/src/api/auth/profile.js
+++ b/src/api/auth/profile.js
@@ -13,7 +13,7 @@ import { tokenFetcher, profileFetcher } from '../../utilities/getGgProfile';
  */
 const megaprofileHandler = async (req, res) => {
   const mp = new MegaProfile();
-  const profileId = req.user.encodedSUID;
+  const profileId = 123 || req.user.encodedSUID;
   const token = await tokenFetcher();
   let fullgg;
   let affiliations;

--- a/src/components/composite/Alert/globalAlert.js
+++ b/src/components/composite/Alert/globalAlert.js
@@ -59,7 +59,7 @@ const GlobalAlert = () => {
           if (!isError || !showAlert) return null;
           return (
             <Alert
-              type="error"
+              type="warning"
               label="Login Error"
               hasDismiss
               dismissFunction={handleDismiss}
@@ -70,7 +70,7 @@ const GlobalAlert = () => {
               If this issue persists, please{' '}
               <a
                 href="https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=0d4e42301ba33410a61d41d5ec4bcbc7"
-                className="su-text-white hocus:su-text-black hocus:su-bg-white"
+                className="su-text-black hocus:su-no-underline hocus:su-text-black"
               >
                 submit a ticket.
               </a>

--- a/src/components/composite/Alert/globalAlert.js
+++ b/src/components/composite/Alert/globalAlert.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { StaticQuery, graphql } from 'gatsby';
 import { SBAlert } from '../../storyblok/alert/alert';
+import { Alert } from './Alert';
 import useSubsite from '../../../hooks/useSubsite';
+import AuthContext from '../../../contexts/AuthContext';
 
 const query = graphql`
   query {
@@ -28,24 +30,55 @@ const query = graphql`
 
 const GlobalAlert = () => {
   const hideAlerts = useSubsite() !== 'homesite';
+  const [showAlert, setShowAlert] = useState(true);
+
+  const handleDismiss = () => {
+    setShowAlert(false);
+  };
 
   return (
-    <StaticQuery
-      query={query}
-      render={({ allStoryblokEntry }) => {
-        if (!allStoryblokEntry?.edges.length || hideAlerts) return null;
-        return (
-          <>
-            {allStoryblokEntry.edges.map(({ node: { content, uuid } }) => {
-              const blok = JSON.parse(content);
-              // eslint-disable-next-line dot-notation
-              blok['_uid'] = uuid;
-              return <SBAlert blok={blok} key={uuid} />;
-            })}
-          </>
-        );
-      }}
-    />
+    <>
+      <StaticQuery
+        query={query}
+        render={({ allStoryblokEntry }) => {
+          if (!allStoryblokEntry?.edges.length || hideAlerts) return null;
+          return (
+            <>
+              {allStoryblokEntry.edges.map(({ node: { content, uuid } }) => {
+                const blok = JSON.parse(content);
+                // eslint-disable-next-line dot-notation
+                blok['_uid'] = uuid;
+                return <SBAlert blok={blok} key={uuid} />;
+              })}
+            </>
+          );
+        }}
+      />
+      <AuthContext.Consumer>
+        {({ isError }) => {
+          if (!isError || !showAlert) return null;
+          return (
+            <Alert
+              type="error"
+              label="Login Error"
+              hasDismiss
+              dismissFunction={handleDismiss}
+            >
+              We weren&apos;t able to log you in with your Stanford profile at
+              this time. Please try again later.
+              <br />
+              If this issue persists, please{' '}
+              <a
+                href="https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=0d4e42301ba33410a61d41d5ec4bcbc7"
+                className="su-text-white hocus:su-text-black hocus:su-bg-white"
+              >
+                submit a ticket.
+              </a>
+            </Alert>
+          );
+        }}
+      </AuthContext.Consumer>
+    </>
   );
 };
 

--- a/src/components/navigation/accountLinks.js
+++ b/src/components/navigation/accountLinks.js
@@ -56,12 +56,12 @@ const AccountLinks = ({ mainLinkClasses }) => {
     },
     {
       text: 'Your Giving',
-      url: 'https://give.stanford.edu',
+      url: 'https://givinghistory.stanford.edu/',
       icon: true,
     },
     {
       text: 'Stanford Groups',
-      url: 'https://alumni.stanford.edu/groups/',
+      url: 'https://groups.stanford.edu/',
       icon: true,
       classes: 'su-pb-16',
     },

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -65,7 +65,6 @@ class AuthContextProvider extends React.Component {
           this.dispatch({ type: 'setAuthenticated', payload: false });
           this.dispatch({ type: 'setAuthenticating', payload: false });
           this.dispatch({ type: 'setError', payload: true });
-          console.log('LOGIN ERROR DUE TO API FAIL.');
           return;
         }
 

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -6,6 +6,7 @@ const initialAuthState = {
   userSession: null,
   isAuthenticated: false,
   isAuthenticating: true,
+  isError: false,
 };
 
 function authReducer(state, action) {
@@ -18,6 +19,8 @@ function authReducer(state, action) {
       return { ...state, userSession: action.payload };
     case 'setUserProfile':
       return { ...state, userProfile: action.payload };
+    case 'setError':
+      return { ...state, isError: action.payload };
     default:
       return state;
   }
@@ -58,6 +61,14 @@ class AuthContextProvider extends React.Component {
     // To be logged in, both session and profile must be available.
     Promise.all([sess, prof])
       .then(([session, profile]) => {
+        if (session && !profile) {
+          this.dispatch({ type: 'setAuthenticated', payload: false });
+          this.dispatch({ type: 'setAuthenticating', payload: false });
+          this.dispatch({ type: 'setError', payload: true });
+          console.log('LOGIN ERROR DUE TO API FAIL.');
+          return;
+        }
+
         if (!session || !profile) {
           this.dispatch({ type: 'setAuthenticated', payload: false });
           this.dispatch({ type: 'setAuthenticating', payload: false });
@@ -72,6 +83,7 @@ class AuthContextProvider extends React.Component {
       .catch((err) => {
         this.dispatch({ type: 'setAuthenticated', payload: false });
         this.dispatch({ type: 'setAuthenticating', payload: false });
+        this.dispatch({ type: 'setError', payload: true });
       });
   }
 
@@ -86,8 +98,13 @@ class AuthContextProvider extends React.Component {
 
   render() {
     const { children } = this.props;
-    const { userProfile, userSession, isAuthenticated, isAuthenticating } =
-      this.state;
+    const {
+      userProfile,
+      userSession,
+      isAuthenticated,
+      isAuthenticating,
+      isError,
+    } = this.state;
     return (
       <AuthContext.Provider
         value={{
@@ -95,6 +112,7 @@ class AuthContextProvider extends React.Component {
           userSession,
           isAuthenticated,
           isAuthenticating,
+          isError,
           setAuthState: this.setAuthState,
         }}
       >


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds a try/catch to fetch profile information from the FullGG endpoint by way of two different oauth tokens
- Adds handling to when a user is able to authenticate with Stanford Pass but not with the API
- Updates the User login links to the ones we had discussed earlier today.

# Review By (Date)
- EOD June 6

# Criticality
- Lowish

# Review Tasks

## Setup tasks and/or behavior to test

1. Review code
2. Navigate to the preview build and log in with a test user
3. Review links in the User utility nav
4. Pull down the code to your local
5. Update your vault variables `npm run vault:local` (Backup your current ones)
6. Change the value of MEGAPROFILE_URL to something invalid
7. Spin up the site `npm run dev` 
8. Login and see the failed login notice in the top 
