### PR TITLE
ADAPT-5012 | @rebeccahongsf | add small plus and minus icon, update icon style on traveler card

### DIFF
--- a/src/components/page-types/registrationFormPage/tripTravelerCard.js
+++ b/src/components/page-types/registrationFormPage/tripTravelerCard.js
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import { FlexBox } from '../../layout/FlexBox';
 import { Heading } from '../../simple/Heading';
 import { FormContext } from '../../../contexts/FormContext';
-import FaIcon from '../../simple/faIcon';
+import HeroIcon from '../../simple/heroIcon';
 
 const TripTravelerCard = ({ traveler }) => {
   const [state, dispatch] = useContext(FormContext);
@@ -42,7 +42,7 @@ const TripTravelerCard = ({ traveler }) => {
   return (
     <button
       type="button"
-      className="su-stretch-link su-w-full su-bg-saa-black-dark"
+      className="su-stretch-link su-w-full su-transition-all su-bg-saa-black-dark su-border-3 su-border-saa-black-dark hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue"
       onClick={toggleRelationship}
     >
       <FlexBox
@@ -65,12 +65,9 @@ const TripTravelerCard = ({ traveler }) => {
           </Heading>
           {traveler?.removeBtn && (
             <p className="su-basefont-23 su-mb-0">
-              <FaIcon
-                iconChoice="fa-check"
-                iconType="far"
-                isOutline="false"
-                fixedWidth
-                className="su-transition-colors su-text-palo-verde-light"
+              <HeroIcon
+                iconType="check"
+                className="su-inline-block su-mb-02em su-text-palo-verde-light"
               />
               Added!
             </p>
@@ -79,24 +76,22 @@ const TripTravelerCard = ({ traveler }) => {
         <FlexBox direction="row" alignItems="center" justifyContent="start">
           {traveler?.removeBtn ? (
             <>
-              <FaIcon
-                iconChoice="fa-minus-circle"
-                iconType="far"
-                isOutline="false"
-                fixedWidth
-                className="su-mr-02em su-transition-colors su-text-digital-red-xlight"
-              />
+              <div className="su-border-2 su-rounded-full su-border-digital-red-xlight su-mr-02em">
+                <HeroIcon
+                  iconType="minus"
+                  className="su-text-digital-red-xlight"
+                />
+              </div>
               <p className="su-basefont-23 su-mb-0">Remove traveler</p>
             </>
           ) : (
             <>
-              <FaIcon
-                iconChoice="fa-plus-circle"
-                iconType="far"
-                isOutline="false"
-                fixedWidth
-                className="su-mr-02em children:su-text-saa-electric-blue children:su-bg-clip-text children:su-bg-gradient-to-tr children:su-from-palo-verde-dark children:su-to-saa-electric-blue"
-              />
+              <div className="su-rounded-full su-p-2 su-bg-gradient-to-bl su-from-saa-electric-blue su-to-palo-verde-dark su-mr-02em">
+                <HeroIcon
+                  iconType="plus"
+                  className="su-text-saa-electric-blue su-rounded-full su-bg-saa-black"
+                />
+              </div>
               <p className="su-basefont-23 su-mb-0">Add traveler</p>
             </>
           )}

--- a/src/components/simple/heroIcon.js
+++ b/src/components/simple/heroIcon.js
@@ -14,6 +14,8 @@ import {
   MailIcon,
   PlayIcon,
   CheckIcon,
+  MinusSmIcon,
+  PlusSmIcon,
 } from '@heroicons/react/solid';
 import { SrOnlyText } from '../accessibility/SrOnlyText';
 
@@ -88,6 +90,18 @@ const HeroIcon = ({ iconType, srText, isAnimate, className, ...props }) => {
     },
     check: {
       heroicon: CheckIcon,
+      baseStyle: 'su-w-1em',
+      animate:
+        'group-hover:su-translate-x-02em group-focus:su-translate-x-02em',
+    },
+    plus: {
+      heroicon: PlusSmIcon,
+      baseStyle: 'su-w-1em',
+      animate:
+        'group-hover:su-translate-x-02em group-focus:su-translate-x-02em',
+    },
+    minus: {
+      heroicon: MinusSmIcon,
       baseStyle: 'su-w-1em',
       animate:
         'group-hover:su-translate-x-02em group-focus:su-translate-x-02em',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- add small plus and minus icon
- update icon style on traveler card

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [`travel-study/italy/registration`](https://deploy-preview-395--stanford-alumni.netlify.app/travel-study/italy/registration)
2. Confirm that the icons are identical in size and the hocus works for traveler card buttons
3. Review code


# Associated Issues and/or People
- ADAPT-5012
