### PR TITLE
ADAPT-5355 and ADAPT-5360s series | @rebeccahongsf |  bulk tsgg updates

### DIFF
--- a/src/api/travel-study/index.js
+++ b/src/api/travel-study/index.js
@@ -60,7 +60,9 @@ const tripsCollection = async (req, res) => {
       tripId: story.content.tripId,
       startDate: story.content.startDate,
       endDate: story.content.endDate,
-      extendPrice: story.content.extendPrice,
+      tripDeposit: story.content.tripDeposit,
+      preExtensionDeposit: story.content.preTripExtensionDeposit,
+      postExtensionDeposit: story.content.postTripExtensionDeposit,
     };
   });
   res.status(200).json(ret);

--- a/src/api/travel-study/reg/post-extension.js
+++ b/src/api/travel-study/reg/post-extension.js
@@ -61,9 +61,7 @@ export default async function handler(req, res) {
     }
 
     if (trip?.content?.postExtendPrice) {
-      const dollarValue = trip.content.postTripExtensionDeposit
-        ? trip.content.postTripExtensionDeposit
-        : trip.content?.extendDepositPrice?.replace(/\D/g, '');
+      const dollarValue = trip.content.postTripExtensionDeposit;
       data.push([
         'prompt',
         trip.content.tripId,

--- a/src/api/travel-study/reg/pre-extension.js
+++ b/src/api/travel-study/reg/pre-extension.js
@@ -61,9 +61,7 @@ export default async function handler(req, res) {
     }
 
     if (trip?.content?.extendPrice) {
-      const dollarValue = trip.content.preTripExtensionDeposit
-        ? trip.content.preTripExtensionDeposit
-        : trip.content?.extendDepositPrice?.replace(/\D/g, '');
+      const dollarValue = trip.content.preTripExtensionDeposit;
       data.push([
         'prompt',
         trip.content.tripId,

--- a/src/components/cta/SAALinkButton.jsx
+++ b/src/components/cta/SAALinkButton.jsx
@@ -21,7 +21,7 @@ const SAALinkButtonProps = {
   children: PropTypes.node,
   link: SBLinkType,
   rel: PropTypes.string,
-  attributes: PropTypes.string,
+  attributes: PropTypes.oneOfType([PropTypes.object]),
   srText: PropTypes.string,
   className: ClassNameType,
 };

--- a/src/components/cta/SAALinkButton.jsx
+++ b/src/components/cta/SAALinkButton.jsx
@@ -21,6 +21,7 @@ const SAALinkButtonProps = {
   children: PropTypes.node,
   link: SBLinkType,
   rel: PropTypes.string,
+  attributes: PropTypes.string,
   srText: PropTypes.string,
   className: ClassNameType,
 };
@@ -35,6 +36,7 @@ export const SAALinkButton = React.forwardRef(
       children,
       link,
       rel,
+      attributes,
       srText,
       className,
       ...rest
@@ -55,7 +57,7 @@ export const SAALinkButton = React.forwardRef(
         <SbLink
           ref={ref}
           link={link}
-          attributes={rel ? { rel } : {}}
+          attributes={attributes || rel ? { rel, ...attributes } : {}}
           classes={dcnb(styles.link, ctaButtonStyle, ctaButtonSize, className)}
           {...rest}
         >

--- a/src/components/embed/dynaScript.js
+++ b/src/components/embed/dynaScript.js
@@ -33,6 +33,8 @@ const DynaScript = ({ errorBlok, src, id, ...props }) => {
 
         // Once GiveGab form has completed rendering, display form
         script.addEventListener('widgetRenderEnd', showForm);
+        // Once GiveGab form has been prompted to the next form page, bring user back to the top of the form
+        script.addEventListener('widgetPageChange', scrollTop);
         // Once GiveGab form has successfully submitted, bring user back to the top of the form
         script.addEventListener('widgetComplete', scrollTop);
       }
@@ -46,6 +48,7 @@ const DynaScript = ({ errorBlok, src, id, ...props }) => {
     return () => {
       mounted = false;
       script.removeEventListener('widgetRenderEnd', showForm);
+      script.removeEventListener('widgetPageChange', scrollTop);
       script.removeEventListener('widgetComplete', scrollTop);
     };
   }, [src, setScriptLoaded, scriptRef]);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -74,6 +74,8 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
   }, [startDate, endDate]);
   const location = useLocation();
 
+  console.log('reservationURL: ', reservationURL);
+
   return (
     <div ref={ref}>
       <TripPageSectionWrapper heading="Overview">
@@ -152,7 +154,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <a
-                  href={location.href}
+                  href={reservationURL?.cached_url}
                   className={styles.reserveBtn}
                   rel="noopener nofollow noreferrer"
                   target="_blank"

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -80,6 +80,8 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
+    // If internal url, remove the paramaters that match the current trip page url and return the end snippet
+    // e.g. reservationURL.cached_url = `register`
     reservationURL.cached_url = reservationURL.cached_url.replace(
       location.pathname.replace(/^\//, ''),
       ''

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -150,7 +150,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <SAALinkButton
-                  link={{ url: reservationURL?.cached_url }}
+                  link={reservationURL}
                   className={{ 'su-w-full': true, 'su-w-fit': false }}
                   align="center"
                   size="small"

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -80,7 +80,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     !reservationURL.cached_url.includes('http')
   ) {
     reservationURL.cached_url = reservationURL.cached_url.replace(
-      location.pathname,
+      location.pathname.replace(/^\//, ''),
       ''
     );
   }

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -75,6 +75,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
   }, [startDate, endDate]);
   const location = useLocation();
 
+  // Checks to see if reservationURL is an internal or external URL
   if (
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
@@ -84,9 +85,6 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
       ''
     );
   }
-
-  console.log('LOCATION: ', location);
-  console.log('URL: ', reservationURL.cached_url);
 
   return (
     <div ref={ref}>

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -150,7 +150,9 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <SAALinkButton
-                  link={reservationURL}
+                  link={{
+                    url: `${location.origin}/${reservationURL?.cached_url}`,
+                  }}
                   className={{ 'su-w-full': true, 'su-w-fit': false }}
                   align="center"
                   size="small"

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -78,7 +78,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    reservationURL.cached_url = `//${location.origin}/${reservationURL.cached_url}`;
+    reservationURL.cached_url = location.origin;
   }
 
   console.log('URL: ', reservationURL.cached_url);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -79,8 +79,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    location.pathname = reservationURL.cached_url;
-    reservationURL.cached_url = `${location.origin}/${location.pathname}`;
+    reservationURL.cached_url = `/register`;
   }
 
   console.log('LOCATION: ', location);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -80,7 +80,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     !reservationURL.cached_url.includes('http')
   ) {
     location.pathname = reservationURL.cached_url;
-    reservationURL.cached_url = location.pathname;
+    reservationURL.cached_url = `${location.origin}/${location.pathname}`;
   }
 
   console.log('LOCATION: ', location);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -75,6 +75,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
   const location = useLocation();
 
   console.log('reservationURL: ', reservationURL);
+  console.log('windowURL: ', window.location);
 
   return (
     <div ref={ref}>

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from '@reach/router';
+import { faGameConsoleHandheld } from '@fortawesome/pro-solid-svg-icons';
 import { Grid } from '../../layout/Grid';
 import { GridCell } from '../../layout/GridCell';
 import { Heading } from '../../simple/Heading';
@@ -78,9 +79,11 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    reservationURL.cached_url = location.origin;
+    location.pathname = reservationURL.cached_url;
+    reservationURL.cached_url = `${location.origin}${location.pathname}`;
   }
 
+  console.log('LOCATION: ', location);
   console.log('URL: ', reservationURL.cached_url);
 
   return (

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -150,10 +150,14 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <SAALinkButton
-                  link={reservationURL}
+                  link={{ url: reservationURL?.cached_url }}
                   className={{ 'su-w-full': true, 'su-w-fit': false }}
                   align="center"
                   size="small"
+                  attributes={{ target: '_blank' }}
+                  rel="noopener nofollower"
+                  srText="Reserve (opens new window)"
+                  icon="external"
                 >
                   Reserve
                 </SAALinkButton>

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -154,10 +154,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
                 <a
                   href={location.href}
                   className={styles.reserveBtn}
-                  align="center"
-                  size="small"
                   rel="noopener nofollow noreferrer"
-                  icon="external"
                   target="_blank"
                 >
                   Reserve

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -79,7 +79,10 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    reservationURL.cached_url = `/register`;
+    reservationURL.cached_url = reservationURL.cached_url.replace(
+      location.pathname,
+      ''
+    );
   }
 
   console.log('LOCATION: ', location);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -78,7 +78,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    reservationURL.cached_url = `${location.origin}/${reservationURL.cached_url}`;
+    reservationURL.cached_url = `//${location.origin}/${reservationURL.cached_url}`;
   }
 
   console.log('URL: ', reservationURL.cached_url);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -80,7 +80,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     !reservationURL.cached_url.includes('http')
   ) {
     location.pathname = reservationURL.cached_url;
-    reservationURL.cached_url = `//${location.host}/${location.pathname}`;
+    reservationURL.cached_url = location.pathname;
   }
 
   console.log('LOCATION: ', location);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -152,7 +152,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <a
-                  href={`${location.href}/register`}
+                  href={location.href}
                   className={styles.reserveBtn}
                   align="center"
                   size="small"

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -74,9 +74,6 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
   }, [startDate, endDate]);
   const location = useLocation();
 
-  console.log('reservationURL: ', reservationURL);
-  console.log('windowURL: ', window.location);
-
   return (
     <div ref={ref}>
       <TripPageSectionWrapper heading="Overview">

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -18,6 +18,8 @@ import { SAALinkButton } from '../../cta/SAALinkButton';
 import { SAAButton } from '../../simple/SAAButton';
 import hasRichText from '../../../utilities/hasRichText';
 import getNumBloks from '../../../utilities/getNumBloks';
+import HeroIcon from '../../simple/heroIcon';
+import { SrOnlyText } from '../../accessibility/SrOnlyText';
 
 export const TripPageOverviewSectionProps = {
   onPrint: PropTypes.func,
@@ -149,18 +151,19 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
                 </div>
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
-                <SAALinkButton
-                  link={reservationURL}
-                  className={{ 'su-w-full': true, 'su-w-fit': false }}
+                <a
+                  href={`${location.origin}/${reservationURL?.cached_url}`}
+                  className={styles.reserveBtn}
                   align="center"
                   size="small"
-                  attributes={{ target: '_blank' }}
-                  rel="noopener nofollow"
-                  srText="Reserve (opens new window)"
+                  rel="noopener nofollow noreferrer"
                   icon="external"
+                  target="_blank"
                 >
                   Reserve
-                </SAALinkButton>
+                  <SrOnlyText>(opens new window)</SrOnlyText>
+                  <HeroIcon iconType="external" isAnimate />
+                </a>
               )}
               {status === 'notify' && inquireURL?.cached_url && (
                 <SAALinkButton

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -74,6 +74,15 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
   }, [startDate, endDate]);
   const location = useLocation();
 
+  if (
+    reservationURL.cached_url &&
+    !reservationURL.cached_url.includes('http')
+  ) {
+    reservationURL.cached_url = `${location.origin}/${reservationURL.cached_url}`;
+  }
+
+  console.log('URL: ', reservationURL.cached_url);
+
   return (
     <div ref={ref}>
       <TripPageSectionWrapper heading="Overview">

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -150,14 +150,12 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <SAALinkButton
-                  link={{
-                    url: `${location.origin}/${reservationURL?.cached_url}`,
-                  }}
+                  link={{ url: reservationURL?.cached_url }}
                   className={{ 'su-w-full': true, 'su-w-fit': false }}
                   align="center"
                   size="small"
                   attributes={{ target: '_blank' }}
-                  rel="noopener nofollower"
+                  rel="noopener nofollow"
                   srText="Reserve (opens new window)"
                   icon="external"
                 >

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -80,7 +80,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
     !reservationURL.cached_url.includes('http')
   ) {
     location.pathname = reservationURL.cached_url;
-    reservationURL.cached_url = `${location.origin}${location.pathname}`;
+    reservationURL.cached_url = `//${location.host}/${location.pathname}`;
   }
 
   console.log('LOCATION: ', location);

--- a/src/components/page-types/TripPage/TripPageOverviewSection.jsx
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.jsx
@@ -152,7 +152,7 @@ export const TripPageOverviewSection = React.forwardRef((props, ref) => {
               )}
               {status === 'reserve' && reservationURL?.cached_url && (
                 <a
-                  href={`${location.origin}/${reservationURL?.cached_url}`}
+                  href={`${location.href}/register`}
                   className={styles.reserveBtn}
                   align="center"
                   size="small"

--- a/src/components/page-types/TripPage/TripPageOverviewSection.styles.js
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.styles.js
@@ -15,4 +15,4 @@ export const actions = 'children:su-mb-20 last:children:su-mb-0';
 export const ctaBtn =
   'su-flex su-min-w-full su-justify-center su-items-end su-py-14 su-mt-16';
 export const reserveBtn =
-  'su-inline-block children:su-inline-block su-group su-border-solid su-border-3 su-transition-colors su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red-xdark hocus:su-text-white hocus:su-border-cardinal-red-xdark hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-26 md:su-pt-14 md:su-pb-16 su-text-18 md:su-text-20 su-w-full';
+  'su-inline-block children:su-inline-block su-text-center su-group su-border-solid su-border-3 su-transition-colors su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red-xdark hocus:su-text-white hocus:su-border-cardinal-red-xdark hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-26 md:su-pt-14 md:su-pb-16 su-text-18 md:su-text-20 su-w-full';

--- a/src/components/page-types/TripPage/TripPageOverviewSection.styles.js
+++ b/src/components/page-types/TripPage/TripPageOverviewSection.styles.js
@@ -14,3 +14,5 @@ export const summaryCost =
 export const actions = 'children:su-mb-20 last:children:su-mb-0';
 export const ctaBtn =
   'su-flex su-min-w-full su-justify-center su-items-end su-py-14 su-mt-16';
+export const reserveBtn =
+  'su-inline-block children:su-inline-block su-group su-border-solid su-border-3 su-transition-colors su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red-xdark hocus:su-text-white hocus:su-border-cardinal-red-xdark hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-26 md:su-pt-14 md:su-pb-16 su-text-18 md:su-text-20 su-w-full';

--- a/src/components/page-types/TripPage/TripPagePricingSection.jsx
+++ b/src/components/page-types/TripPage/TripPagePricingSection.jsx
@@ -34,7 +34,7 @@ export const TripPagePricingSection = React.forwardRef((props, ref) => {
           body={pricingBody}
         />
         {getNumBloks(pricingBelowContent) > 0 && (
-          <div className="trip-page-pricing-below-content">
+          <div className="trip-page-pricing-below-content children:lg:su-scroll-margin-top-130">
             <CreateBloks blokSection={pricingBelowContent} />
           </div>
         )}

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { MenuIcon, XIcon } from '@heroicons/react/outline';
+import { useLocation } from '@reach/router';
 import { Container } from '../../layout/Container';
 import * as styles from './TripPageSectionNav.styles';
 import { SBLinkType } from '../../../types/storyblok/SBLinkType';
@@ -34,6 +35,7 @@ export const TripPageSectionNav = (props) => {
     activeSection,
   } = props;
 
+  const location = useLocation();
   const [navOpened, setNavOpened] = useState(false);
   const ref = useRef(null);
   const burgerRef = useRef(null);
@@ -117,7 +119,7 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <SAALinkButton
-            link={reservationURL}
+            link={{ url: `${location.origin}/${reservationURL?.cached_url}` }}
             size="small-short"
             className={styles.button}
             attributes={{ target: '_blank' }}

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { MenuIcon, XIcon } from '@heroicons/react/outline';
+import { useLocation } from '@reach/router';
 import { Container } from '../../layout/Container';
 import * as styles from './TripPageSectionNav.styles';
 import { SBLinkType } from '../../../types/storyblok/SBLinkType';
@@ -38,12 +39,16 @@ export const TripPageSectionNav = (props) => {
   const [navOpened, setNavOpened] = useState(false);
   const ref = useRef(null);
   const burgerRef = useRef(null);
+  const location = useLocation();
 
   if (
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    reservationURL.cached_url = `/register`;
+    reservationURL.cached_url = reservationURL.cached_url.replace(
+      location.pathname,
+      ''
+    );
   }
 
   const toggleNav = () => {

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -120,7 +120,7 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <a
-            href={`${location.origin}/${reservationURL?.cached_url}`}
+            href={`${location.href}/register`}
             className={styles.reserveBtn}
             align="center"
             size="small"

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -9,6 +9,8 @@ import { SAALinkButton } from '../../cta/SAALinkButton';
 import useEscape from '../../../hooks/useEscape';
 import useOnClickOutside from '../../../hooks/useOnClickOutside';
 import { isExpanded } from '../../../utilities/menuHelpers';
+import HeroIcon from '../../simple/heroIcon';
+import { SrOnlyText } from '../../accessibility/SrOnlyText';
 
 export const TripPageSectionNavProps = {
   renderFacultySection: PropTypes.bool,
@@ -34,11 +36,10 @@ export const TripPageSectionNav = (props) => {
     reservationURL,
     activeSection,
   } = props;
-
-  const location = useLocation();
   const [navOpened, setNavOpened] = useState(false);
   const ref = useRef(null);
   const burgerRef = useRef(null);
+  const location = useLocation();
 
   const toggleNav = () => {
     setNavOpened(!navOpened);
@@ -118,17 +119,19 @@ export const TripPageSectionNav = (props) => {
           )}
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
-          <SAALinkButton
-            link={reservationURL}
-            size="small-short"
-            className={styles.button}
-            attributes={{ target: '_blank' }}
-            rel="noopener nofollow"
-            srText="Reserve (opens new window)"
+          <a
+            href={`${location.origin}/${reservationURL?.cached_url}`}
+            className={styles.reserveBtn}
+            align="center"
+            size="small"
+            rel="noopener nofollow noreferrer"
             icon="external"
+            target="_blank"
           >
             Reserve
-          </SAALinkButton>
+            <SrOnlyText>(opens new window)</SrOnlyText>
+            <HeroIcon iconType="external" isAnimate />
+          </a>
         )}
         {status === 'notify' && inquireURL?.cached_url && (
           <SAALinkButton

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -120,7 +120,7 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <a
-            href={location.href}
+            href={reservationURL?.cached_url}
             className={styles.reserveBtn}
             rel="noopener nofollow noreferrer"
             target="_blank"
@@ -216,7 +216,7 @@ export const TripPageSectionNav = (props) => {
             {status === 'reserve' && reservationURL?.cached_url && (
               <div className={styles.buttonWrapperMobile}>
                 <a
-                  href={location.href}
+                  href={reservationURL?.cached_url}
                   className={styles.reserveBtn}
                   rel="noopener nofollow noreferrer"
                   target="_blank"

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -120,12 +120,9 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <a
-            href={`${location.href}/register`}
+            href={location.href}
             className={styles.reserveBtn}
-            align="center"
-            size="small"
             rel="noopener nofollow noreferrer"
-            icon="external"
             target="_blank"
           >
             Reserve
@@ -218,13 +215,16 @@ export const TripPageSectionNav = (props) => {
             </ul>
             {status === 'reserve' && reservationURL?.cached_url && (
               <div className={styles.buttonWrapperMobile}>
-                <SAALinkButton
-                  link={reservationURL}
-                  className={styles.buttonMobile}
-                  size="small"
+                <a
+                  href={location.href}
+                  className={styles.reserveBtn}
+                  rel="noopener nofollow noreferrer"
+                  target="_blank"
                 >
                   Reserve
-                </SAALinkButton>
+                  <SrOnlyText>(opens new window)</SrOnlyText>
+                  <HeroIcon iconType="external" isAnimate />
+                </a>
               </div>
             )}
             {status === 'notify' && inquireURL?.cached_url && (

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -46,7 +46,7 @@ export const TripPageSectionNav = (props) => {
     !reservationURL.cached_url.includes('http')
   ) {
     reservationURL.cached_url = reservationURL.cached_url.replace(
-      location.pathname,
+      location.pathname.replace(/^\//, ''),
       ''
     );
   }

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -41,6 +41,7 @@ export const TripPageSectionNav = (props) => {
   const burgerRef = useRef(null);
   const location = useLocation();
 
+  // Checks to see if reservationURL is an internal or external URL
   if (
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -41,6 +41,14 @@ export const TripPageSectionNav = (props) => {
   const burgerRef = useRef(null);
   const location = useLocation();
 
+  if (
+    reservationURL.cached_url &&
+    !reservationURL.cached_url.includes('http')
+  ) {
+    location.pathname = reservationURL.cached_url;
+    reservationURL.cached_url = `${location.origin}/${location.pathname}`;
+  }
+
   const toggleNav = () => {
     setNavOpened(!navOpened);
   };

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -46,6 +46,8 @@ export const TripPageSectionNav = (props) => {
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
+    // If internal url, remove the paramaters that match the current trip page url and return the end snippet
+    // e.g. reservationURL.cached_url = `register`
     reservationURL.cached_url = reservationURL.cached_url.replace(
       location.pathname.replace(/^\//, ''),
       ''

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -117,9 +117,13 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <SAALinkButton
-            link={reservationURL}
+            link={{ url: reservationURL?.cached_url }}
             size="small-short"
             className={styles.button}
+            attributes={{ target: '_blank' }}
+            rel="noopener nofollower"
+            srText="Reserve (opens new window)"
+            icon="external"
           >
             Reserve
           </SAALinkButton>

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { MenuIcon, XIcon } from '@heroicons/react/outline';
-import { useLocation } from '@reach/router';
 import { Container } from '../../layout/Container';
 import * as styles from './TripPageSectionNav.styles';
 import { SBLinkType } from '../../../types/storyblok/SBLinkType';
@@ -39,14 +38,12 @@ export const TripPageSectionNav = (props) => {
   const [navOpened, setNavOpened] = useState(false);
   const ref = useRef(null);
   const burgerRef = useRef(null);
-  const location = useLocation();
 
   if (
     reservationURL.cached_url &&
     !reservationURL.cached_url.includes('http')
   ) {
-    location.pathname = reservationURL.cached_url;
-    reservationURL.cached_url = `${location.origin}/${location.pathname}`;
+    reservationURL.cached_url = `/register`;
   }
 
   const toggleNav = () => {

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -230,7 +230,7 @@ export const TripPageSectionNav = (props) => {
               <div className={styles.buttonWrapperMobile}>
                 <a
                   href={reservationURL?.cached_url}
-                  className={styles.reserveBtn}
+                  className={styles.reserveMobileBtn}
                   rel="noopener nofollow noreferrer"
                   target="_blank"
                 >

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -119,11 +119,11 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <SAALinkButton
-            link={{ url: `${location.origin}/${reservationURL?.cached_url}` }}
+            link={{ url: reservationURL?.cached_url }}
             size="small-short"
             className={styles.button}
             attributes={{ target: '_blank' }}
-            rel="noopener nofollower"
+            rel="noopener nofollow"
             srText="Reserve (opens new window)"
             icon="external"
           >

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -119,7 +119,7 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <SAALinkButton
-            link={{ url: reservationURL?.cached_url }}
+            link={reservationURL}
             size="small-short"
             className={styles.button}
             attributes={{ target: '_blank' }}

--- a/src/components/page-types/TripPage/TripPageSectionNav.jsx
+++ b/src/components/page-types/TripPage/TripPageSectionNav.jsx
@@ -117,7 +117,7 @@ export const TripPageSectionNav = (props) => {
         </ul>
         {status === 'reserve' && reservationURL?.cached_url && (
           <SAALinkButton
-            link={{ url: reservationURL?.cached_url }}
+            link={reservationURL}
             size="small-short"
             className={styles.button}
             attributes={{ target: '_blank' }}

--- a/src/components/page-types/TripPage/TripPageSectionNav.styles.js
+++ b/src/components/page-types/TripPage/TripPageSectionNav.styles.js
@@ -51,3 +51,5 @@ export const buttonWrapperMobile = 'su-px-20 md:su-px-30 su-rs-py-2';
 export const buttonMobile = '!su-w-full su-text-center su-text-21';
 export const reserveBtn =
   'su-inline-block children:su-inline-block su-w-fit su-group su-border-solid su-border-3 su-transition-colors su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red-xdark hocus:su-text-white hocus:su-border-cardinal-red-xdark hocus:su-shadow-md su-px-20 su-pt-7 su-pb-8 md:su-px-26 md:su-pt-8 md:su-pb-10 su-text-18 md:su-text-20 su-ml-[6rem] xl:su-ml-[8rem] su-mt-[-0.5rem]';
+export const reserveMobileBtn =
+  'su-inline-block children:su-inline-block su-w-fit su-group su-border-solid su-border-3 su-transition-colors su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red-xdark hocus:su-text-white hocus:su-border-cardinal-red-xdark hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-26 md:su-pt-14 md:su-pb-16 su-text-18 md:su-text-20 !su-w-full su-text-center su-text-21';

--- a/src/components/page-types/TripPage/TripPageSectionNav.styles.js
+++ b/src/components/page-types/TripPage/TripPageSectionNav.styles.js
@@ -49,3 +49,5 @@ export const linkMobile =
   'su-group su-block su-no-underline su-border-l-5 su-border-saa-black su-py-14 su-pl-10 su-pr-20 su-transition-all su-text-white su-text-21 hocus:su-text-digital-red-xlight hocus:su-border-digital-red-xlight hocus:su-underline';
 export const buttonWrapperMobile = 'su-px-20 md:su-px-30 su-rs-py-2';
 export const buttonMobile = '!su-w-full su-text-center su-text-21';
+export const reserveBtn =
+  'su-inline-block children:su-inline-block su-w-fit su-group su-border-solid su-border-3 su-transition-colors su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red-xdark hocus:su-text-white hocus:su-border-cardinal-red-xdark hocus:su-shadow-md su-px-20 su-pt-7 su-pb-8 md:su-px-26 md:su-pt-8 md:su-pb-10 su-text-18 md:su-text-20 su-ml-[6rem] xl:su-ml-[8rem] su-mt-[-0.5rem]';

--- a/src/components/page-types/registrationFormPage/interstitialPage.js
+++ b/src/components/page-types/registrationFormPage/interstitialPage.js
@@ -260,7 +260,7 @@ const InterstitialPage = (props) => {
                         </>
                       ) : (
                         <p className={styles.travelerEmptyText}>
-                          No additional travelers are available at this time
+                          No existing connections are available at this time
                         </p>
                       )}
                     </FlexBox>

--- a/src/components/page-types/registrationFormPage/interstitialPage.js
+++ b/src/components/page-types/registrationFormPage/interstitialPage.js
@@ -205,7 +205,7 @@ const InterstitialPage = (props) => {
                       <br />
                       {extensionDeposit && (
                         <>
-                          For extensions, an additional deposit of
+                          For extensions, an additional deposit of{` `}
                           {formatUSD.format(extensionDeposit)} per traveler is
                           required.
                         </>

--- a/src/components/page-types/registrationFormPage/interstitialPage.js
+++ b/src/components/page-types/registrationFormPage/interstitialPage.js
@@ -163,6 +163,12 @@ const InterstitialPage = (props) => {
   const extensionDeposit =
     preTripExtensionDeposit || postTripExtensionDeposit || false;
 
+  const formatUSD = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+
   return (
     <AuthenticatedPage>
       <FormContextProvider>
@@ -194,32 +200,21 @@ const InterstitialPage = (props) => {
                       Before you register
                     </Heading>
                     <p className={styles.gridText}>
-                      A deposit of ${tripDeposit.toLocaleString('en-US')} per
-                      traveler is required upon registration.
+                      A deposit of {formatUSD.format(tripDeposit)} per traveler
+                      is required upon registration.
                       <br />
                       {extensionDeposit && (
                         <>
-                          For extensions, an additional deposit of $
-                          {extensionDeposit.toLocaleString('en-US')} per
-                          traveler is required.
+                          For extensions, an additional deposit of
+                          {formatUSD.format(extensionDeposit)} per traveler is
+                          required.
                         </>
                       )}
                     </p>
                     <p className={styles.gridText}>
-                      Looking to give this trip as a gift? To ensure that your
-                      gift is kept private, please register for this trip by
-                      {` `}
-                      <a
-                        href="tel:+16507251093"
-                        className={styles.contactNumber}
-                      >
-                        giving us a call
-                        <HeroIcon
-                          iconType="external"
-                          className={styles.externalIcon}
-                          isAnimate
-                        />
-                      </a>
+                      Looking to surprise someone with this trip? Enter your
+                      email in place of theirs to ensure that your gift is kept
+                      private.
                     </p>
                   </GridCell>
                 </Grid>

--- a/src/components/page-types/registrationFormPage/registrationFormPage.js
+++ b/src/components/page-types/registrationFormPage/registrationFormPage.js
@@ -178,19 +178,6 @@ const RegistrationFormPage = (props) => {
             >
               <Hero blok={heroProps} />
               <Grid gap xs={12} className={styles.contentWrapper}>
-                <GridCell xs={12}>
-                  <div className="su-text-white">
-                    <Heading
-                      level={2}
-                      align="center"
-                      font="serif"
-                      className={styles.header}
-                    >
-                      {tripTitle}:<br />
-                      Registration
-                    </Heading>
-                  </div>
-                </GridCell>
                 <GridCell
                   xs={12}
                   md={10}

--- a/src/components/page-types/registrationFormPage/tripTravelerList.js
+++ b/src/components/page-types/registrationFormPage/tripTravelerList.js
@@ -31,7 +31,7 @@ const TripTravelerList = () => {
       })}
       {state.travelersData.length === 1 && (
         <p className="su-text-center su-basefont-23">
-          You haven’t yet added any additional travelers.
+          You haven’t yet added any existing connections.
         </p>
       )}
     </FlexBox>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -120,8 +120,7 @@
 }
 
 
-.ggeWidget .ggeQuestion.su-email .ggeQuestion__field textarea,
-.ggeWidget .ggeQuestion .ggeQuestion__field  textarea[id*='ContactEmail'] {
+.ggeWidget .ggeQuestion.su-email .ggeQuestion__field textarea {
   @apply su-h-[6.8rem] su-overflow-hidden su-min-h-[2.8rem];
 }
 
@@ -134,7 +133,7 @@
   @apply su-min-h-[138px];
 }
 
-.ggeWidget .ggeQuestion .ggeQuestion__field fieldset[id*="TripExtension"] legend {
+.ggeWidget .ggeQuestion.su-extension .ggeQuestion__field fieldset legend {
   @apply su-hidden;
 }
 
@@ -305,7 +304,7 @@
 }
 
 /* Email Other Type */
-.ggeWidget .ggeQuestion [id*='EmailType'] .ggePrompt__label label {
+.ggeWidget .ggeQuestion su-email-type .ggePrompt__label label {
   @apply su-capitalize;
 }
 
@@ -326,7 +325,7 @@
 
 .ggeWidget .ggeContent .ggeQuestion.su-phone,
 .ggeWidget .ggeContent .ggeQuestion.su-email,
-.ggeWidget .ggeContent .ggeQuestion textarea[id*='ContactEmail'] {
+.ggeWidget .ggeContent .ggeQuestion.su-email textarea {
   @apply su-text-black-30;
 }
 

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -405,7 +405,7 @@
 }
 
 .ggeConfirmation .ggeButton {
-  @apply su-m-auto lg:su-text-[2.4rem];
+  @apply su-m-auto lg:su-text-[2.4rem] su-normal-case;
 }
 
 .ggeConfirmation .ggeTally--header {
@@ -547,7 +547,7 @@
 }
 
 .ggeWidget .ggeButton--addRegistrant {
-  @apply su-bg-transparent su-text-white su-border-0 su-px-0 su-pr-0 su-pl-[2.7rem] su-text-21 su-bg-no-repeat;
+  @apply su-bg-transparent su-text-white su-border-0 su-px-0 su-pr-0 su-pl-[2.7rem] su-big-paragraph su-bg-no-repeat;
   background-position: left center;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='21' height='20' viewBox='0 0 21 20' fill='none'%3E%3Cpath d='M10.5 7V10M10.5 10V13M10.5 10H13.5M10.5 10H7.5M19.5 10C19.5 14.9706 15.4706 19 10.5 19C5.52944 19 1.5 14.9706 1.5 10C1.5 5.02944 5.52944 1 10.5 1C15.4706 1 19.5 5.02944 19.5 10Z' stroke='%23F83535' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -120,7 +120,8 @@
 }
 
 
-.ggeWidget .ggeQuestion.su-email .ggeQuestion__field textarea {
+.ggeWidget .ggeQuestion.su-email .ggeQuestion__field textarea,
+.ggeWidget .ggeQuestion .ggeQuestion__field  textarea[id*='ContactEmail'] {
   @apply su-h-[6.8rem] su-overflow-hidden su-min-h-[2.8rem];
 }
 
@@ -324,7 +325,8 @@
 }
 
 .ggeWidget .ggeContent .ggeQuestion.su-phone,
-.ggeWidget .ggeContent .ggeQuestion.su-email {
+.ggeWidget .ggeContent .ggeQuestion.su-email,
+.ggeWidget .ggeContent .ggeQuestion textarea[id*='ContactEmail'] {
   @apply su-text-black-30;
 }
 

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -348,6 +348,10 @@
   display: none;
 }
 
+.public-additional-payment .ggeQuestion.su-reservation-id {
+  @apply su-mt-45;
+}
+
 .ggeWidget .ggeQuestion.ggeQuestion--mobilepayment #ggeNoMobileLabel {
   text-transform: lowercase;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[Batches requested fixes from TSGG](https://docs.google.com/spreadsheets/d/1pCukzFMRrFqoeMzej08lKv_FKgbcu-umrTOK8ss7mxI/edit#gid=1871597942)
- Open Reserve form link in new tab (no additional changes to SB needed)
- Update Added Travelers empty state text on interstitial page
- Remove `Trip: Registration` header from registration form
- Increase "Add Traveler" link on GG registration form payment page
- Resolve cancellation policy anchor link over-scroll
- Update "Explore More Destinations" from title casing to sentence casing ("Explore more destinations") on Notify me confirmation page
- Update intro text on interstitial page
- Update trip deposits to display as USD currency values

# Review By (Date)
- Sooner the better please! Thank you 🙏 

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to [`travel-study/destinations/italy-test`](https://deploy-preview-458--stanford-alumni.netlify.app/travel-study/destinations/italy-test)
3. Verify that upon clicking "Reserve", the registration form opens in a new window/tab
4. On the interstitial page, confirm that the text for Added Travelers has been updated to "You haven't yet added any existing connections"
5. Continue onward to the registration form
- Confirm that the additional header "Trip: Registration" no longer appears between the hero and form
6. When moving through the form, confirm that you are brought back to the top of the form upon clicking next to move onward. 
7. On the payment summary, 
- Confirm that the font of "Add traveler" is using `su-big-paragraph`
- Open the Cancellation policy link and confirm that it directs user to the deposit section of trip.
8. Navigate to [`travel-study/destinations/italy-test/notify`](https://deploy-preview-458--stanford-alumni.netlify.app/travel-study/destinations/italy-test/notify)
9. Submit the form.
10. Confirm that the onscreen confirmation displays the proper casing for "Explore more destinations" button
11. Review code to see if anything looks questionable

# Associated Issues and/or People
- ADAPT-5355
- ADAPT-5361
- ADAPT-5362
- ADAPT-5363
- ADAPT-5364
- ADAPT-5365
- ADAPT-5367
- ADAPT-5391