### PR TITLE
ADAPT-5375 | Itinerary last item should display accommodation and meals

### DIFF
--- a/src/components/composite/itineraryItem.js
+++ b/src/components/composite/itineraryItem.js
@@ -22,7 +22,7 @@ const ItineraryItem = ({ blok }) => {
     image: { filename, focus } = {},
     caption,
   } = blok;
-  // First take all but the last selected meal options and joins them together with a comma.
+  // First take all but the last selected meal options and joins them together with a comma
   // Joins that string and the last element with "and" if there are at least two meal options selected.
   const mealsString = [meals.slice(0, -1).join(', '), meals.slice(-1)[0]].join(
     meals.length < 2 ? '' : ' and '

--- a/src/components/composite/itineraryItem.js
+++ b/src/components/composite/itineraryItem.js
@@ -33,7 +33,7 @@ const ItineraryItem = ({ blok }) => {
 
   return (
     <SbEditable content={blok}>
-      <li className="itinerary-item su-group su-mb-0 last:children:children:first:children:last:su-hidden last:children:children:last:su-pb-0 su-basefont-21">
+      <li className="itinerary-item su-group su-mb-0 last:children:children:first:children:last:su-bg-transparent last:children:children:last:su-pb-0 su-basefont-21">
         <Grid
           alignItems="stretch"
           className="su-grid-flow-col su-grid-cols-auto-1fr su-w-full su-break-words su-gap-x-xs md:su-gap-x-[5rem] xl:su-gap-x-[7rem]"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The last item in the itinerary should display accommodation and or meals if they are entered

# Review By (Date)
- Soon


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-460--stanford-alumni.netlify.app/travel-study/destinations/everest-2022/#itinerary-section
2. Scroll to the last itinerary step, the meal should be displayed

You can compare to currently on dev, it doesn't display the meals on the last day
https://dev--stanford-alumni.netlify.app/travel-study/destinations/everest-2022/#itinerary-section

3. Look at code


# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
