### PR TITLE
NOJIRA | @rebeccahongsf | hide remove btn for primary reg

### DIFF
--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -446,7 +446,7 @@
 /* Registration form specific  */
 div.ggeRegistrant--prefilled[data-registrantid="1"] .ggeButton--discardRegistrant,
 .geeTally .ggeTally__multireg__button.ggeTally__multireg__button--delete:first {
-  @apply su-hidden; 
+  @apply su-hidden;
 }
 
 .ggeRegistrantList,

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -444,7 +444,8 @@
 }
 
 /* Registration form specific  */
-div.ggeRegistrant--prefilled[data-registrantid="1"] .ggeButton--discardRegistrant {
+div.ggeRegistrant--prefilled[data-registrantid="1"] .ggeButton--discardRegistrant,
+.geeTally .ggeTally__multireg__button.ggeTally__multireg__button--delete:first {
   @apply su-hidden;
 }
 

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -446,7 +446,7 @@
 /* Registration form specific  */
 div.ggeRegistrant--prefilled[data-registrantid="1"] .ggeButton--discardRegistrant,
 .geeTally .ggeTally__multireg__button.ggeTally__multireg__button--delete:first {
-  @apply su-hidden;
+  @apply su-hidden; 
 }
 
 .ggeRegistrantList,

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -444,6 +444,10 @@
 }
 
 /* Registration form specific  */
+div.ggeRegistrant--prefilled[data-registrantid="1"] .ggeButton--discardRegistrant {
+  @apply su-hidden;
+}
+
 .ggeRegistrantList,
 .ggeWidget .ggeSection--askArray.ggeSection--registration,
 .ggePage--payment .ggePageNav--back {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- since the primary registrant/travel must always attend the trip, hide remove btn option specifically for the primary reg

# Review By (Date)
- Friday morning, 10/14 

# Review Tasks

## Setup tasks and/or behavior to test

1. Login as zguan
2. Navigate to `travel-study/destinations/italy-test/register`
3. Select an additional traveler or two
4. Continue to through the form
5. On the payment summary page, confirm that the `remove` text doesn't display for the primary registrant
6. Edit the primary registrant and confirm that the `Remove traveler` link doesn't display
7. Go back to the payment summary page and edit an additional traveler
8. Confirm that the `remove traveler` link displays.
9. Review code 👾 
