### PR TITLE
ADAPTSM-42 | @rebeccahongsf | fixup gatsby node config

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,6 +17,7 @@ exports.createPages = ({ graphql, actions }) => {
       'perk',
       'redirect', // NOTE: Redirects are are specifically generated below
       'registrationFormPage', // Note: Handled separately
+      'membershipFormPage', // Note: Handled separately below
       'searchEntry',
       'searchKeywordBanner',
       'searchSuggestions',


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- exclude membershipFormPage from component

# Steps
1. Check out this branch
2. Navigate to [http://localhost:8000/membership/register/](http://localhost:8000/membership/register/)
3. Verify that your interstitial page displays
4. Navigate to [http://localhost:8000/membership/register/form](http://localhost:8000/membership/register/form)
5. Verify that the membership form page displays

# Associated Issues and/or People
- ADAPTSM-42