### PR TITLE
ADAPTSM-55 | @rebeccahongsf | create related contact selection interstitial page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,6 +17,7 @@ exports.createPages = ({ graphql, actions }) => {
       'perk',
       'redirect', // NOTE: Redirects are are specifically generated below
       'registrationFormPage', // Note: Handled separately
+      'membershipFormPage', // Note: Handled separately below
       'searchEntry',
       'searchKeywordBanner',
       'searchSuggestions',
@@ -226,15 +227,29 @@ exports.createPages = ({ graphql, actions }) => {
             },
           });
 
+          // Create type of registrant interstitial page
+          // createPage({
+          //   path: `/${pagePath}`,
+          //   component: storyblokEntry,
+          //   context: {
+          //     slug: membershipEntry.node.full_slug,
+          //     story: membershipEntry.node,
+          //     isCanonical,
+          //     noIndex,
+          //     membershipInterstitial: true,
+          //   },
+          // });
+
+          // Create related contact selection interstitial page
           createPage({
-            path: `/${pagePath}`,
+            path: `/${pagePath}/related-contacts`,
             component: storyblokEntry,
             context: {
               slug: membershipEntry.node.full_slug,
               story: membershipEntry.node,
               isCanonical,
               noIndex,
-              interstitial: true,
+              membershipRelatedContact: true,
             },
           });
         });

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -73,6 +73,7 @@ import TripFilterPage from './page-types/TripFilterPage/TripFilterPage';
 import TripFormInformation from './composite/tripFormInformation';
 import TripNotifyMe from './page-types/formPage/tripNotifyMe';
 import TripPage from './page-types/TripPage/TripPage';
+import RelatedContactSelection from './page-types/membershipFormPage/relatedContactSelection';
 import { SBUtilityNav } from './storyblok/utilityNav';
 import VerticalNav from './navigation/verticalNav';
 import VerticalNavWrapper from './navigation/verticalNavWrapper';
@@ -154,6 +155,7 @@ const ComponentList = {
   tsContentTemplate: SBTsContentTemplate,
   tripFormInformation: TripFormInformation,
   tripNotifyMe: TripNotifyMe,
+  relatedContactSelection: RelatedContactSelection,
   utilityNav: SBUtilityNav,
   verticalNav: VerticalNav,
   verticalNavWrapper: VerticalNavWrapper,

--- a/src/components/page-types/membershipFormPage/membershipFormPage.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.js
@@ -23,11 +23,18 @@ const MembershipFormPage = (props) => {
       ankleContent,
     },
     blok,
+    location,
   } = props;
 
   const { userProfile } = useContext(AuthContext);
   const numAnkle = getNumBloks(ankleContent);
   const helmetTitle = `Stanford Alumni Association Membership`;
+  const registrant = location?.state?.registrant;
+  console.log('REGISTRANT PASS THROUGH: ', registrant);
+
+  useEffect(() => {
+    window.prefillData = registrant;
+  }, [registrant]);
 
   return (
     <AuthenticatedPage>

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -64,9 +64,9 @@ const RelatedContactSelection = (props) => {
   };
   const relatedContacts = structureRelatedContactData(relationships);
 
-  const selectRelatedContact = (relatedContact) => {
-    console.log('Selected!');
-    return setSelectedContact[relatedContact];
+  const selectRelatedContact = (data) => {
+    console.log('DATA: ', data);
+    setSelectedContact(data);
   };
 
   return (
@@ -132,18 +132,18 @@ const RelatedContactSelection = (props) => {
                   <FlexBox>
                     {/* DISPLAY RELATED CONTACTS HERE */}
                     {relatedContacts.map((relatedContact) => (
-                      <div className="su-p-2 su-b-1">
+                      <div className={styles.tempCard}>
                         <p>{relatedContact.su_dname}</p>
                         <p>{relatedContact.su_reg}</p>
                         <SAAButton
                           icon="none"
-                          onClick={selectRelatedContact(relatedContact)}
+                          onClick={() => selectRelatedContact(relatedContact)}
                         >
                           Select
                         </SAAButton>
                       </div>
                     ))}
-                    <div className="su-p-2 su-b-1">
+                    <div className={styles.tempCard}>
                       <p>Add New Contact</p>
                       <p>New contact</p>
                       <SAAButton icon="plus">Create new</SAAButton>

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -74,7 +74,7 @@ const RelatedContactSelection = (props) => {
     <AuthenticatedPage>
       <SbEditable content={blok}>
         <Helmet titleTemplate={helmetTitle} title={helmetTitle} />
-        <Layout hasHero="true" {...props}>
+        <Layout {...props}>
           <Container
             as="main"
             id="main-content"
@@ -97,13 +97,7 @@ const RelatedContactSelection = (props) => {
               className={styles.contentWrapper}
               id="su-gg-embed"
             >
-              <GridCell
-                xs={12}
-                md={10}
-                xl={8}
-                xxl={6}
-                className={styles.formWrapper}
-              >
+              <GridCell xs={12} md={10} className={styles.formWrapper}>
                 <div className={styles.contentStyle}>
                   <span className={styles.superHead}>
                     Stanford Alumni Association Membership
@@ -130,26 +124,64 @@ const RelatedContactSelection = (props) => {
                   <p>
                     Please select a recipient from your list of contacts below.
                   </p>
-                  <FlexBox>
+                  <Grid gap xs={12} className="su-rs-pb-2 su-rs-pt-1">
                     {/* DISPLAY RELATED CONTACTS HERE */}
                     {relatedContacts.map((relatedContact) => (
-                      <div className={styles.tempCard}>
-                        <p>{relatedContact.su_dname}</p>
-                        <p>{relatedContact.su_reg}</p>
-                        <SAAButton
-                          icon="none"
-                          onClick={() => selectRelatedContact(relatedContact)}
-                        >
-                          Select
-                        </SAAButton>
-                      </div>
+                      <GridCell xs={12} md={6}>
+                        <div className="su-border-3 su-px-90 su-py-58">
+                          <FlexBox justifyContent="center">
+                            <FlexBox
+                              justifyContent="center"
+                              alignItems="center"
+                              className="su-leading su-text-center su-w-50 su-h-50 su-text-24 su-border-2 su-rounded-full"
+                              aria-hidden="true"
+                            >
+                              <span>{relatedContact.su_dname.slice(0, 1)}</span>
+                            </FlexBox>
+                          </FlexBox>
+                          <div className="su-text-center su-type-2 su-font-bold su-rs-mt-1 su-leading">
+                            {relatedContact.su_dname}
+                          </div>
+                          <div className="su-text-center su-leading ">
+                            {relatedContact.su_reg}
+                          </div>
+                          <FlexBox justifyContent="center">
+                            <SAAButton
+                              icon="none"
+                              onClick={() =>
+                                selectRelatedContact(relatedContact)
+                              }
+                            >
+                              Select
+                            </SAAButton>
+                          </FlexBox>
+                        </div>
+                      </GridCell>
                     ))}
-                    <div className={styles.tempCard}>
-                      <p>Add New Contact</p>
-                      <p>New contact</p>
-                      <SAAButton icon="plus">Create new</SAAButton>
-                    </div>
-                  </FlexBox>
+                    <GridCell xs={12} md={6}>
+                      <div className="su-border-3 su-px-90 su-py-58">
+                        <FlexBox justifyContent="center">
+                          <FlexBox
+                            justifyContent="center"
+                            alignItems="center"
+                            className="su-leading su-text-center su-w-50 su-h-50 su-text-24 su-border-2 su-rounded-full"
+                            aria-hidden="true"
+                          >
+                            <HeroIcon iconType="plus" />
+                          </FlexBox>
+                        </FlexBox>
+                        <div className="su-text-center su-type-2 su-font-bold su-rs-mt-1 su-leading">
+                          Add new contact
+                        </div>
+                        <div className="su-text-center su-leading ">
+                          New contact
+                        </div>
+                        <FlexBox justifyContent="center">
+                          <SAAButton icon="plus">Create new</SAAButton>
+                        </FlexBox>
+                      </div>
+                    </GridCell>
+                  </Grid>
                   <FlexBox>
                     <Link
                       to="/membership/register/form"

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -1,0 +1,184 @@
+import React, { useContext, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import SbEditable from 'storyblok-react';
+import { Link } from 'gatsby';
+import { Container } from '../../layout/Container';
+import { Heading } from '../../simple/Heading';
+import { HeroImage } from '../../composite/HeroImage/HeroImage';
+import Layout from '../../partials/layout';
+import { Grid } from '../../layout/Grid';
+import AuthContext from '../../../contexts/AuthContext';
+import AuthenticatedPage from '../../auth/AuthenticatedPage';
+import { GridCell } from '../../layout/GridCell';
+import * as styles from './relatedContactSelection.styles';
+import { formatUsDate } from '../../../utilities/transformDate';
+import { FlexBox } from '../../layout/FlexBox';
+import HeroIcon from '../../simple/heroIcon';
+import { SAAButton } from '../../simple/SAAButton';
+
+const RelatedContactSelection = (props) => {
+  const {
+    blok: { heroImage: { filename, alt, focus } = {} },
+    blok,
+    location,
+  } = props;
+  const helmetTitle = `Stanford Alumni Association Membership`;
+  const slug = location.pathname.replace(/\/$/, '');
+  const [selectedContact, setSelectedContact] = useState([]);
+
+  const { userProfile } = useContext(AuthContext);
+  const relationships = userProfile?.relationships;
+
+  const structureRelatedContactData = (relationshipsData = []) => {
+    let relatedContacts = [];
+    let data = {};
+    relationshipsData?.forEach((relationship) => {
+      data = {
+        su_did: relationship?.relatedContactEncodedID,
+        su_dname: relationship?.relatedContactDigitalName
+          ? relationship?.relatedContactDigitalName
+          : `${relationship?.relatedContactFullNameParsed?.relatedContactFirstName} ${relationship?.relatedContactFullNameParsed?.relatedContactLastName}`,
+        su_title:
+          relationship?.relatedContactFullNameParsed?.relatedContactPrefix,
+        su_first_name:
+          relationship?.relatedContactFullNameParsed?.relatedContactFirstName,
+        su_middle_name:
+          relationship?.relatedContactFullNameParsed
+            ?.relatedContactMiddleName === null
+            ? '&nbsp;'
+            : relationship?.relatedContactFullNameParsed
+                ?.relatedContactMiddleName,
+        su_last_name:
+          relationship?.relatedContactFullNameParsed?.relatedContactLastName,
+        su_relation: relationship?.relationshipType,
+        su_dob: relationship?.relatedContactBirthDate
+          ? formatUsDate(relationship?.relatedContactBirthDate)
+          : '',
+        su_reg: 'Related contact',
+        su_email: undefined,
+        su_phone: undefined,
+      };
+      relatedContacts = [...relatedContacts, data];
+    });
+    return relatedContacts;
+  };
+  const relatedContacts = structureRelatedContactData(relationships);
+
+  const selectRelatedContact = (relatedContact) => {
+    console.log('Selected!');
+    return setSelectedContact[relatedContact];
+  };
+
+  return (
+    <AuthenticatedPage>
+      <SbEditable content={blok}>
+        <Helmet titleTemplate={helmetTitle} title={helmetTitle} />
+        <Layout hasHero="true" {...props}>
+          <Container
+            as="main"
+            id="main-content"
+            className={styles.container}
+            width="full"
+          >
+            <div className={styles.fixedHero}>
+              <HeroImage
+                filename={filename}
+                alt={alt}
+                focus={focus}
+                overlay="formDark"
+                aspectRatio="5x2"
+                className={styles.fixedHeroImg}
+              />
+            </div>
+            <Grid
+              gap
+              xs={12}
+              className={styles.contentWrapper}
+              id="su-gg-embed"
+            >
+              <GridCell
+                xs={12}
+                md={10}
+                xl={8}
+                xxl={6}
+                className={styles.formWrapper}
+              >
+                <div className={styles.contentStyle}>
+                  <span className={styles.superHead}>
+                    Stanford Alumni Association Membership
+                  </span>
+                  <Heading
+                    level={1}
+                    size="6"
+                    align="center"
+                    font="serif"
+                    id="page-title"
+                  >
+                    Welcome,{' '}
+                    {userProfile?.name?.fullNameParsed?.firstName ||
+                      userProfile?.session.firstName}
+                  </Heading>
+                </div>
+                <div className={styles.contactWrapper}>
+                  {/* Alumni logo here */}
+                  <Heading>Select a recipient</Heading>
+                  <p>
+                    Help someone become a membership of the Stanford Alumni
+                    Association.
+                  </p>
+                  <p>
+                    Please select a recipient from your list of contacts below.
+                  </p>
+                  <FlexBox>
+                    {/* DISPLAY RELATED CONTACTS HERE */}
+                    {relatedContacts.map((relatedContact) => (
+                      <div className="su-p-2 su-b-1">
+                        <p>{relatedContact.su_dname}</p>
+                        <p>{relatedContact.su_reg}</p>
+                        <SAAButton
+                          icon="none"
+                          onClick={selectRelatedContact(relatedContact)}
+                        >
+                          Select
+                        </SAAButton>
+                      </div>
+                    ))}
+                    <div className="su-p-2 su-b-1">
+                      <p>Add New Contact</p>
+                      <p>New contact</p>
+                      <SAAButton icon="plus">Create new</SAAButton>
+                    </div>
+                  </FlexBox>
+                  <FlexBox>
+                    <Link
+                      to={`${slug}/form`}
+                      className={styles.contactLink}
+                      state={{ registrant: selectedContact }}
+                    >
+                      Next
+                      <HeroIcon
+                        iconType="arrow-right"
+                        className={styles.contactLinkIcon}
+                        isAnimate
+                      />
+                    </Link>
+                  </FlexBox>
+                  <p>
+                    Please note: All memberships, both domestic and
+                    international, will have access to a{' '}
+                    <a href="/">digital membership card</a> in lieu of a
+                    physical membership packet. Additionally, we are unable to
+                    send SAA Member key tags to addresses outside of the US.
+                    (note linked digital membership card)
+                  </p>
+                </div>
+              </GridCell>
+            </Grid>
+          </Container>
+        </Layout>
+      </SbEditable>
+    </AuthenticatedPage>
+  );
+};
+
+export default RelatedContactSelection;

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -14,8 +14,8 @@ import * as styles from './relatedContactSelection.styles';
 import { formatUsDate } from '../../../utilities/transformDate';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
-import { SAAButton } from '../../simple/SAAButton';
-import { SAALinkButton } from '../../cta/SAALinkButton';
+import Logo from '../../identity/logo';
+import MembershipCard from './membershipCard';
 
 const RelatedContactSelection = (props) => {
   const {
@@ -24,7 +24,7 @@ const RelatedContactSelection = (props) => {
     pageContext,
   } = props;
   const helmetTitle = `Stanford Alumni Association Membership`;
-  // TODO: Determine how slug can be passed into the Gatsby Link as an absolute vs addition
+  // @TODO: Determine how slug can be passed into the Gatsby Link as an absolute vs addition
   const slug = pageContext.slug.replace(/\/$/, '');
   const [selectedContact, setSelectedContact] = useState([]);
 
@@ -65,11 +65,6 @@ const RelatedContactSelection = (props) => {
     return relatedContacts;
   };
   const relatedContacts = structureRelatedContactData(relationships);
-
-  const selectRelatedContact = (data) => {
-    console.log('DATA: ', data);
-    setSelectedContact(data);
-  };
 
   return (
     <AuthenticatedPage>
@@ -116,7 +111,9 @@ const RelatedContactSelection = (props) => {
                   </Heading>
                 </div>
                 <div className={styles.contactWrapper}>
-                  {/* Alumni logo here */}
+                  <FlexBox justifyContent="center" className="su-rs-py-2">
+                    <Logo className="su-w-200 md:su-w-300 2xl:su-w-[350px]" />
+                  </FlexBox>
                   <Heading>Select a recipient</Heading>
                   <p className="su-mb-0">
                     Help someone become a membership of the Stanford Alumni
@@ -129,91 +126,68 @@ const RelatedContactSelection = (props) => {
                     {/* DISPLAY RELATED CONTACTS HERE */}
                     {relatedContacts.map((relatedContact) => (
                       <GridCell xs={12} md={6}>
-                        <div className="su-border-3 su-px-90 su-py-58">
-                          <FlexBox justifyContent="center">
-                            <FlexBox
-                              justifyContent="center"
-                              alignItems="center"
-                              className="su-leading su-text-center su-w-50 su-h-50 su-text-24 su-border-2 su-rounded-full"
-                              aria-hidden="true"
-                            >
-                              <span>{relatedContact.su_dname.slice(0, 1)}</span>
-                            </FlexBox>
-                          </FlexBox>
-                          <div className="su-text-center su-type-2 su-font-bold su-rs-mt-1 su-leading">
-                            {relatedContact.su_dname}
-                          </div>
-                          <div className="su-text-center su-leading ">
-                            {relatedContact.su_reg}
-                          </div>
-                          <FlexBox justifyContent="center">
-                            <SAAButton
-                              icon="none"
-                              onClick={() =>
-                                selectRelatedContact(relatedContact)
-                              }
-                            >
-                              Select
-                            </SAAButton>
-                          </FlexBox>
-                        </div>
+                        <MembershipCard
+                          heading={relatedContact.su_dname}
+                          subheading={relatedContact.su_reg}
+                          initial={relatedContact.su_dname.slice(0, 1)}
+                        />
                       </GridCell>
                     ))}
                     <GridCell xs={12} md={6}>
-                      <div className="su-border-3 su-px-90 su-py-58">
-                        <FlexBox justifyContent="center">
-                          <FlexBox
-                            justifyContent="center"
-                            alignItems="center"
-                            className="su-leading su-text-center su-w-50 su-h-50 su-text-24 su-border-2 su-rounded-full"
-                            aria-hidden="true"
-                          >
-                            <HeroIcon iconType="plus" />
-                          </FlexBox>
-                        </FlexBox>
-                        <div className="su-text-center su-type-2 su-font-bold su-rs-mt-1 su-leading">
-                          Add new contact
-                        </div>
-                        <div className="su-text-center su-leading ">
-                          New contact
-                        </div>
-                        <FlexBox justifyContent="center">
-                          <SAAButton icon="plus">Create new</SAAButton>
-                        </FlexBox>
-                      </div>
+                      <MembershipCard
+                        heading="New Contact"
+                        subheading="Add new contact"
+                        newContact
+                      />
                     </GridCell>
                   </Grid>
-                  <FlexBox justifyContent="evenly" alignItems="center">
-                    <SAALinkButton icon="none" link="/membership/register">
+                  <FlexBox
+                    justifyContent="evenly"
+                    alignItems="center"
+                    className="su-rs-mb-4"
+                  >
+                    <Link
+                      to="/membership/register"
+                      className={styles.goBackLink}
+                    >
                       <HeroIcon
                         iconType="arrow-left"
-                        className="su-inline-block"
+                        className={styles.goBackLinkIcon}
                         isAnimate
                       />
                       Go back
-                    </SAALinkButton>
+                    </Link>
                     <Link
                       to="/membership/register/form"
-                      className={styles.contactLink}
+                      className={styles.nextLink(selectedContact)}
                       state={{ registrant: selectedContact }}
                     >
                       Next
                       <HeroIcon
                         iconType="arrow-right"
-                        className={styles.contactLinkIcon}
-                        isAnimate
+                        className={styles.nextLinkIcon}
+                        isAnimate={!selectedContact}
                       />
                     </Link>
                   </FlexBox>
                   {/* TODO: Inquire about digital membership card link */}
-                  <p>
-                    Please note: All memberships, both domestic and
-                    international, will have access to a{' '}
-                    <a href="/">digital membership card</a> in lieu of a
-                    physical membership packet. Additionally, we are unable to
-                    send SAA Member key tags to addresses outside of the US.
-                    (note linked digital membership card)
-                  </p>
+                  <Grid gap xs={12}>
+                    <GridCell xs={12} md={8} className="md:su-col-start-3">
+                      <p className="su-text-center">
+                        Please note: All memberships, both domestic and
+                        international, will have access to a{' '}
+                        <a
+                          className="su-text-white hocus:su-text-digital-red-light"
+                          href="/"
+                        >
+                          digital membership card
+                        </a>{' '}
+                        in lieu of a physical membership packet. Additionally,
+                        we are unable to send SAA Member key tags to addresses
+                        outside of the US. (note linked digital membership card)
+                      </p>
+                    </GridCell>
+                  </Grid>
                 </div>
               </GridCell>
             </Grid>

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -15,6 +15,7 @@ import { formatUsDate } from '../../../utilities/transformDate';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import { SAAButton } from '../../simple/SAAButton';
+import { SAALinkButton } from '../../cta/SAALinkButton';
 
 const RelatedContactSelection = (props) => {
   const {
@@ -24,7 +25,7 @@ const RelatedContactSelection = (props) => {
   } = props;
   const helmetTitle = `Stanford Alumni Association Membership`;
   // TODO: Determine how slug can be passed into the Gatsby Link as an absolute vs addition
-  // const slug = pageContext.slug.replace(/\/$/, '');
+  const slug = pageContext.slug.replace(/\/$/, '');
   const [selectedContact, setSelectedContact] = useState([]);
 
   const { userProfile } = useContext(AuthContext);
@@ -117,7 +118,7 @@ const RelatedContactSelection = (props) => {
                 <div className={styles.contactWrapper}>
                   {/* Alumni logo here */}
                   <Heading>Select a recipient</Heading>
-                  <p>
+                  <p className="su-mb-0">
                     Help someone become a membership of the Stanford Alumni
                     Association.
                   </p>
@@ -182,7 +183,15 @@ const RelatedContactSelection = (props) => {
                       </div>
                     </GridCell>
                   </Grid>
-                  <FlexBox>
+                  <FlexBox justifyContent="evenly" alignItems="center">
+                    <SAALinkButton icon="none" link="/membership/register">
+                      <HeroIcon
+                        iconType="arrow-left"
+                        className="su-inline-block"
+                        isAnimate
+                      />
+                      Go back
+                    </SAALinkButton>
                     <Link
                       to="/membership/register/form"
                       className={styles.contactLink}

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -20,10 +20,11 @@ const RelatedContactSelection = (props) => {
   const {
     blok: { heroImage: { filename, alt, focus } = {} },
     blok,
-    location,
+    pageContext,
   } = props;
   const helmetTitle = `Stanford Alumni Association Membership`;
-  const slug = location.pathname.replace(/\/$/, '');
+  // TODO: Determine how slug can be passed into the Gatsby Link as an absolute vs addition
+  // const slug = pageContext.slug.replace(/\/$/, '');
   const [selectedContact, setSelectedContact] = useState([]);
 
   const { userProfile } = useContext(AuthContext);
@@ -151,7 +152,7 @@ const RelatedContactSelection = (props) => {
                   </FlexBox>
                   <FlexBox>
                     <Link
-                      to={`${slug}/form`}
+                      to="/membership/register/form"
                       className={styles.contactLink}
                       state={{ registrant: selectedContact }}
                     >
@@ -163,6 +164,7 @@ const RelatedContactSelection = (props) => {
                       />
                     </Link>
                   </FlexBox>
+                  {/* TODO: Inquire about digital membership card link */}
                   <p>
                     Please note: All memberships, both domestic and
                     international, will have access to a{' '}

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
@@ -1,3 +1,5 @@
+import { dcnb } from 'cnbuilder';
+
 export const container = 'basic-page su-relative su-flex-grow su-w-full';
 export const fixedHero = 'su-fixed su-top-0 su-z-0 su-h-full su-w-full';
 export const fixedHeroImg = 'su-object-cover su-h-full su-w-full';
@@ -8,10 +10,18 @@ export const superHead =
 export const contentWrapper = 'su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6';
 export const formWrapper = 'md:su-col-start-2';
 export const contentStyle = 'su-text-white';
-export const contactLink =
-  'su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-border-3 su-border-digital-red-xlight su-text-white hocus:su-bg-digital-red hocus:su-border-digital-red hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18';
-export const contactLinkIcon =
-  'su-w-1em su-text-digital-red-xlight group-hocus:su-text-white';
+export const nextLink = (disabled) =>
+  dcnb(
+    'su-group su-flex su-items-end su-text-18 md:su-text-24 su-no-underline su-font-regular su-text-white hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18',
+    disabled
+      ? 'su-pointer-events-none su-bg-black-70 su-border-black-70 hocus:su-bg-black-70 hocus:su-border-black-70'
+      : 'hocus:su-underline su-bg-digital-red su-border-digital-red hocus:su-bg-cardinal-red-xdark hocus:su-border-cardinal-red-xdark'
+  );
+export const nextLinkIcon = 'su-w-1em su-text-white group-hocus:su-text-white';
+export const goBackLink =
+  'su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline hocus:su-underline su-text-white hocus:su-text-white su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18 su-border-solid su-border-3 su-transition-colors su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-bg-transparent group-hocus:su-text-white group-hocus:su-bg-gradient-to-tr group-hocus:su-from-palo-verde-dark group-hocus:su-to-saa-electric-blue group-hocus:su-shadow-md';
+export const goBackLinkIcon =
+  'su-w-1em su-text-white group-hocus:su-text-white';
 export const contactWrapper =
   'su-flex su-flex-col su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6 su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm su-bg-saa-black-dark';
 export const tempCard = 'su-rs-p-2 su-border-white su-border-2';

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
@@ -6,8 +6,7 @@ export const superHead =
   'su-block su-max-w-prose su-font-semibold su-leading-display su-text-shadow-md su-type-2 su-text-center su-mx-auto su-mb-01em';
 
 export const contentWrapper = 'su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6';
-export const formWrapper =
-  'md:su-col-start-2 xl:su-col-start-3 2xl:su-col-start-4';
+export const formWrapper = 'md:su-col-start-2';
 export const contentStyle = 'su-sticky su-top-0 su-h-fit su-text-white';
 export const contactLink =
   'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-border-3 su-border-digital-red-xlight su-text-white hocus:su-bg-digital-red hocus:su-border-digital-red hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18';

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
@@ -15,3 +15,4 @@ export const contactLinkIcon =
   'su-w-1em su-text-digital-red-xlight group-hocus:su-text-white';
 export const contactWrapper =
   'su-flex su-flex-col su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6 su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm su-bg-saa-black-dark';
+export const tempCard = 'su-rs-p-2 su-border-white su-border-2';

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
@@ -7,9 +7,9 @@ export const superHead =
 
 export const contentWrapper = 'su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6';
 export const formWrapper = 'md:su-col-start-2';
-export const contentStyle = 'su-sticky su-top-0 su-h-fit su-text-white';
+export const contentStyle = 'su-text-white';
 export const contactLink =
-  'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-border-3 su-border-digital-red-xlight su-text-white hocus:su-bg-digital-red hocus:su-border-digital-red hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18';
+  'su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-border-3 su-border-digital-red-xlight su-text-white hocus:su-bg-digital-red hocus:su-border-digital-red hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18';
 export const contactLinkIcon =
   'su-w-1em su-text-digital-red-xlight group-hocus:su-text-white';
 export const contactWrapper =

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.styles.js
@@ -1,0 +1,17 @@
+export const container = 'basic-page su-relative su-flex-grow su-w-full';
+export const fixedHero = 'su-fixed su-top-0 su-z-0 su-h-full su-w-full';
+export const fixedHeroImg = 'su-object-cover su-h-full su-w-full';
+
+export const superHead =
+  'su-block su-max-w-prose su-font-semibold su-leading-display su-text-shadow-md su-type-2 su-text-center su-mx-auto su-mb-01em';
+
+export const contentWrapper = 'su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6';
+export const formWrapper =
+  'md:su-col-start-2 xl:su-col-start-3 2xl:su-col-start-4';
+export const contentStyle = 'su-sticky su-top-0 su-h-fit su-text-white';
+export const contactLink =
+  'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-border-3 su-border-digital-red-xlight su-text-white hocus:su-bg-digital-red hocus:su-border-digital-red hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18';
+export const contactLinkIcon =
+  'su-w-1em su-text-digital-red-xlight group-hocus:su-text-white';
+export const contactWrapper =
+  'su-flex su-flex-col su-shadow-lg su-text-white su-rs-p-5 md:su-rs-p-6 su-bg-gradient-to-tl su-to-saa-black su-from-saa-black-opacity-40 su-backdrop-blur-sm su-bg-saa-black-dark';

--- a/src/templates/storyblok-entry.js
+++ b/src/templates/storyblok-entry.js
@@ -51,6 +51,16 @@ class StoryblokEntry extends React.Component {
       content.component = 'interstitialPage';
     }
 
+    // Swap the page component for membership type of registrant interstitial page.
+    // if (pageContext.membershipInterstitial) {
+    // content.component = 'typeOfRegistrant';
+    // }
+
+    // Swap the page component for membership related contact interstitial page
+    if (pageContext.membershipRelatedContact) {
+      content.component = 'relatedContactSelection';
+    }
+
     return (
       <>
         {React.createElement(Components(content.component), {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- scaffold the related contact selection interstitial page
- tweak membership styling
Note: Additional styling and adjustments to the data flow will be made in[ ADAPTSM-54](https://stanfordits.atlassian.net/browse/ADAPTSM-54) and [ADAPTSM-56](https://stanfordits.atlassian.net/browse/ADAPTSM-56)

# Review By (Date)
- when possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [`membership/register/related-contacts`](https://deploy-preview-533--stanford-alumni.netlify.app/membership/register/related-contacts)
2. Login as `zguan`
3. Verify that the user's relationship(s) display. (Currently, there is only one relationship)
4. Confirm that the Next button displays as disabled by default and the user cannot continue to the form page.
5. Review code 👾 

# Associated Issues and/or People
- [ADAPTSM-55](https://stanfordits.atlassian.net/browse/ADAPTSM-55)
- [ADAPTSM-35](https://stanfordits.atlassian.net/browse/ADAPTSM-35)