### PR TITLE
ADAPTSM-25 | @rebeccahongsf | add membership info blocks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -24,6 +24,7 @@ const storyblokRelations = [
   'registrationFormPage.trip',
   'giveGabForm.failureMessage',
   'failureMessage.giveGabErrorMessage',
+  'membershipInformation.membershipInfoText',
 ];
 
 // Support for Gatsby CLI

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -40,6 +40,7 @@ import MainNavItem from './navigation/MainNav/mainNavItem';
 import Masthead from './identity/masthead';
 import MastheadPicker from './identity/mastheadPicker';
 import MembershipFormPage from './page-types/membershipFormPage/membershipFormPage';
+import MembershipInformation from './page-types/membershipFormPage/membershipInformation';
 import NavItem from './navigation/navItem';
 import Page from './page';
 import Perk from './content-types/perk/perk';
@@ -123,6 +124,7 @@ const ComponentList = {
   masthead: Masthead,
   mastheadPicker: MastheadPicker,
   membershipFormPage: MembershipFormPage,
+  membershipInformation: MembershipInformation,
   navItem: NavItem,
   page: Page,
   perk: Perk,

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -41,6 +41,7 @@ import Masthead from './identity/masthead';
 import MastheadPicker from './identity/mastheadPicker';
 import MembershipFormPage from './page-types/membershipFormPage/membershipFormPage';
 import MembershipInformation from './page-types/membershipFormPage/membershipInformation';
+import MembershipInfoText from './page-types/membershipFormPage/membershipInfoText';
 import NavItem from './navigation/navItem';
 import Page from './page';
 import Perk from './content-types/perk/perk';
@@ -125,6 +126,7 @@ const ComponentList = {
   mastheadPicker: MastheadPicker,
   membershipFormPage: MembershipFormPage,
   membershipInformation: MembershipInformation,
+  membershipInfoText: MembershipInfoText,
   navItem: NavItem,
   page: Page,
   perk: Perk,

--- a/src/components/page-types/membershipFormPage/membershipInfoText.js
+++ b/src/components/page-types/membershipFormPage/membershipInfoText.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import SbEditable from 'storyblok-react';
+import { FlexBox } from '../../layout/FlexBox';
+import { Heading } from '../../simple/Heading';
+import HeroIcon from '../../simple/heroIcon';
+import * as styles from './membershipInformation.styles';
+
+const MembershipInfoText = ({
+  blok: {
+    heading,
+    body,
+    displayBenefitsButton,
+    benefitsButtonText,
+    benefitsLink,
+  },
+  blok,
+}) => (
+  <SbEditable content={blok}>
+    <Heading level={2} size={2} align="left" font="sans">
+      {heading}
+    </Heading>
+    <p className="su-card-paragraph">{body}</p>
+    {displayBenefitsButton && (
+      <FlexBox justifyContent="center">
+        <a href={benefitsLink} className={styles.benefitsLink}>
+          {benefitsButtonText || 'Benefits of Membership'}
+          <HeroIcon
+            iconType="arrow-right"
+            className={styles.benefitsLinkIcon}
+            isAnimate
+          />
+        </a>
+      </FlexBox>
+    )}
+  </SbEditable>
+);
+
+export default MembershipInfoText;

--- a/src/components/page-types/membershipFormPage/membershipInformation.js
+++ b/src/components/page-types/membershipFormPage/membershipInformation.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import SbEditable from 'storyblok-react';
+import { Heading } from '../../simple/Heading';
+
+const MembershipInformation = (props) => {
+  const {
+    blok: { heading, body, benefitsLink },
+    blok,
+  } = props;
+  console.log('BLOK: ', blok);
+
+  return (
+    <SbEditable content={blok}>
+      <Heading level={1} size={6} align="left" font="serif" id="page-title">
+        {heading}
+      </Heading>
+      <p>{body}</p>
+      <a href={benefitsLink}>Become a Member</a>
+    </SbEditable>
+  );
+};
+
+export default MembershipInformation;

--- a/src/components/page-types/membershipFormPage/membershipInformation.js
+++ b/src/components/page-types/membershipFormPage/membershipInformation.js
@@ -1,21 +1,40 @@
 import React from 'react';
 import SbEditable from 'storyblok-react';
+import { FlexBox } from '../../layout/FlexBox';
 import { Heading } from '../../simple/Heading';
+import HeroIcon from '../../simple/heroIcon';
+import * as styles from './membershipInformation.styles';
 
 const MembershipInformation = (props) => {
   const {
-    blok: { heading, body, benefitsLink },
+    blok: {
+      heading,
+      body,
+      displayBenefitsButton,
+      benefitsButtonText,
+      benefitsLink,xw
+    },
     blok,
   } = props;
-  console.log('BLOK: ', blok);
 
   return (
     <SbEditable content={blok}>
-      <Heading level={1} size={6} align="left" font="serif" id="page-title">
+      <Heading level={2} size={2} align="left" font="sans">
         {heading}
       </Heading>
-      <p>{body}</p>
-      <a href={benefitsLink}>Become a Member</a>
+      <p className="su-card-paragraph">{body}</p>
+      {displayBenefitsButton && (
+        <FlexBox justifyContent="center">
+          <a href={benefitsLink} className={styles.benefitsLink}>
+            {benefitsButtonText || 'Benefits of Membership'}
+            <HeroIcon
+              iconType="arrow-right"
+              className={styles.benefitsLinkIcon}
+              isAnimate
+            />
+          </a>
+        </FlexBox>
+      )}
     </SbEditable>
   );
 };

--- a/src/components/page-types/membershipFormPage/membershipInformation.js
+++ b/src/components/page-types/membershipFormPage/membershipInformation.js
@@ -8,11 +8,15 @@ import * as styles from './membershipInformation.styles';
 const MembershipInformation = (props) => {
   const {
     blok: {
-      heading,
-      body,
-      displayBenefitsButton,
-      benefitsButtonText,
-      benefitsLink,xw
+      membershipInfoText: {
+        content: {
+          heading,
+          body,
+          displayBenefitsButton,
+          benefitsButtonText,
+          benefitsLink,
+        },
+      },
     },
     blok,
   } = props;

--- a/src/components/page-types/membershipFormPage/membershipInformation.styles.js
+++ b/src/components/page-types/membershipFormPage/membershipInformation.styles.js
@@ -1,0 +1,3 @@
+export const benefitsLink =
+  'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-border-3 su-border-digital-red-xlight su-text-white hocus:su-bg-digital-red hocus:su-border-digital-red hocus:su-text-white hocus:su-shadow-md su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18';
+export const benefitsLinkIcon = 'su-w-1em su-text-white';

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -16,10 +16,11 @@ import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import Logo from '../../identity/logo';
 import MembershipCard from './membershipCard';
+import CreateBloks from '../../../utilities/createBloks';
 
 const RelatedContactSelection = (props) => {
   const {
-    blok: { heroImage: { filename, alt, focus } = {} },
+    blok: { heroImage: { filename, alt, focus } = {}, membershipCardNote },
     blok,
     pageContext,
   } = props;
@@ -170,22 +171,9 @@ const RelatedContactSelection = (props) => {
                       />
                     </Link>
                   </FlexBox>
-                  {/* TODO: Inquire about digital membership card link */}
                   <Grid gap xs={12}>
                     <GridCell xs={12} md={8} className="md:su-col-start-3">
-                      <p className="su-text-center">
-                        Please note: All memberships, both domestic and
-                        international, will have access to a{' '}
-                        <a
-                          className="su-text-white hocus:su-text-digital-red-light"
-                          href="/"
-                        >
-                          digital membership card
-                        </a>{' '}
-                        in lieu of a physical membership packet. Additionally,
-                        we are unable to send SAA Member key tags to addresses
-                        outside of the US. (note linked digital membership card)
-                      </p>
+                      <CreateBloks blokSection={membershipCardNote} />
                     </GridCell>
                   </Grid>
                 </div>

--- a/src/components/page-types/membershipFormPage/typeOfRegistrant.js
+++ b/src/components/page-types/membershipFormPage/typeOfRegistrant.js
@@ -117,7 +117,7 @@ const TypeOfRegistrant = (props) => {
                   </FlexBox>
                   <Grid gap xs={12}>
                     <GridCell xs={12} md={8} className="md:su-col-start-3">
-                      {/* <CreateBloks blokSection={membershipCardNote} /> */}
+                      <CreateBloks blokSection={membershipCardNote} />
                     </GridCell>
                   </Grid>
                 </div>

--- a/src/components/page-types/membershipFormPage/typeOfRegistrant.js
+++ b/src/components/page-types/membershipFormPage/typeOfRegistrant.js
@@ -15,10 +15,15 @@ import Logo from '../../identity/logo';
 import MembershipCard from './membershipCard';
 import AuthContext from '../../../contexts/AuthContext';
 import * as styles from './typeOfRegistrant.styles';
+import CreateBloks from '../../../utilities/createBloks';
 
 const TypeOfRegistrant = (props) => {
   const {
-    blok: { heroImage: { filename, alt, focus } = {} },
+    blok: {
+      heroImage: { filename, alt, focus } = {},
+      intro,
+      membershipCardNote,
+    },
     blok,
   } = props;
 
@@ -70,28 +75,7 @@ const TypeOfRegistrant = (props) => {
                   <FlexBox justifyContent="center" className="su-rs-py-2">
                     <Logo className="su-w-200 md:su-w-300 2xl:su-w-[350px]" />
                   </FlexBox>
-                  <p className="su-intro-text">
-                    Become a member of the Stanford Alumni Association and
-                    you&apos;ll enjoy a host of benefits.
-                  </p>
-                  <p>
-                    To be eligible for alumni membership, you need to have
-                    completed a minimum of three quarters of matriculated
-                    coursework at either the undergraduate or graduate level.
-                    Stanford faculty, staff, interns, residents, fellows,
-                    certificate holders, postdocs, Travel/Study participants
-                    Stanford parents are eligible for an affiliate membership.
-                  </p>
-                  <FlexBox justifyContent="center">
-                    <Link to="/" className={styles.benefitsLink}>
-                      Benefits of Membership
-                      <HeroIcon
-                        iconType="arrow-right"
-                        className={styles.benefitsLinkIcon}
-                        isAnimate
-                      />
-                    </Link>
-                  </FlexBox>
+                  <CreateBloks blokSection={intro} />
                 </div>
               </GridCell>
               <GridCell xs={12}>
@@ -131,16 +115,9 @@ const TypeOfRegistrant = (props) => {
                       />
                     </Link>
                   </FlexBox>
-
                   <Grid gap xs={12}>
                     <GridCell xs={12} md={8} className="md:su-col-start-3">
-                      <p className="su-text-center su-rs-py-2">
-                        Please note: All memberships, both domestic and
-                        international, will have access to a digital membership
-                        card card in lieu of a physical membership packet.
-                        Additionally, we are unable to send SAA Member key tags
-                        to of the US.
-                      </p>
+                      {/* <CreateBloks blokSection={membershipCardNote} /> */}
                     </GridCell>
                   </Grid>
                 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- add membership info into an editable block 
- add digital membership card into an editable block 
**NOTE: Additional styling will be done within [ADAPTSM-43](https://stanfordits.atlassian.net/browse/ADAPTSM-43)**

# Review By (Date)
- when convenient

# Review Tasks

## Setup tasks and/or behavior to test

1. Review [StoryBlok content authoring env for Membership Reg page](https://app.storyblok.com/#/me/spaces/184821/stories/0/0/224400868)
2. Navigate to [`/membership/global-membership-information/`](https://deploy-preview-538--stanford-alumni.netlify.app/membership/global-membership-information/) to see the preview
3. Navigate to [`/membership/register`](https://deploy-preview-538--stanford-alumni.netlify.app/membership/register) to see the membership intro info and membership card info
4. Review code 👾 

# Associated Issues and/or People
- ADAPTSM-25

[ADAPTSM-43]: https://stanfordits.atlassian.net/browse/ADAPTSM-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ