### PR TITLE
ADAPTSM-118 | @rebeccahongsf | update select ux and add digitalName

### DIFF
--- a/src/components/page-types/membershipFormPage/MembershipCard.styles.js
+++ b/src/components/page-types/membershipFormPage/MembershipCard.styles.js
@@ -1,14 +1,7 @@
-import { dcnb } from 'cnbuilder';
-
 export const root =
   'su-group su-relative su-overflow-hidden su-bg-saa-black-dark su-break-words su-border-black su-w-full sm:su-max-w-[42rem] md:su-max-w-full';
-export const membershipCardWrapper = (disabled) =>
-  dcnb(
-    'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-border-3 su-border-white',
-    disabled
-      ? 'su-pointer-events-none'
-      : 'hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue'
-  );
+export const membershipCardWrapper =
+  'su-bg-saa-black su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue';
 export const initialAndSelectionWrapper =
   'su-flex-col lg:su-flex-row su-items-center su-gap-xs su-relative';
 export const initialWrapper =
@@ -20,12 +13,7 @@ export const checkLinkIcon =
 export const heading =
   'su-text-center su-type-2 su-font-bold su-rs-mt-1 su-leading';
 export const subheading = 'su-text-center su-type-0';
-export const membershipCardLink = (disabled) =>
-  dcnb(
-    'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-text-white su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18 su-border-solid su-border-3 su-transition-colors su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-bg-transparent',
-    disabled
-      ? 'su-pointer-events-none'
-      : 'group-hocus:su-text-white group-hocus:su-bg-gradient-to-tr group-hocus:su-from-palo-verde-dark group-hocus:su-to-saa-electric-blue group-hocus:su-shadow-md'
-  );
+export const membershipCardLink =
+  'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-text-white su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18 su-border-solid su-border-3 su-transition-colors su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-bg-transparent group-hocus:su-text-white group-hocus:su-bg-gradient-to-tr group-hocus:su-from-palo-verde-dark group-hocus:su-to-saa-electric-blue group-hocus:su-shadow-md';
 export const membershipCardSelectedLink =
   'su-rs-mt-2 su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-text-white su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18 su-border-solid su-border-3 su-transition-colors su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-text-white su-bg-gradient-to-tr su-from-palo-verde-dark su-to-saa-electric-blue su-shadow-md hocus:su-text-white';

--- a/src/components/page-types/membershipFormPage/MembershipCard.styles.js
+++ b/src/components/page-types/membershipFormPage/MembershipCard.styles.js
@@ -1,7 +1,14 @@
+import { dcnb } from 'cnbuilder';
+
 export const root =
   'su-group su-relative su-overflow-hidden su-bg-saa-black-dark su-break-words su-border-black su-w-full sm:su-max-w-[42rem] md:su-max-w-full';
-export const membershipCardWrapper =
-  'su-bg-saa-black su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue';
+export const membershipCardWrapper = (newContact, isSelected) => {
+  dcnb(
+    'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue',
+    newContact ? 'su-border-dashed' : 'su-border-solid',
+    isSelected && 'su-bg-saa-black su-border-solid'
+  );
+};
 export const initialAndSelectionWrapper =
   'su-flex-col lg:su-flex-row su-items-center su-gap-xs su-relative';
 export const initialWrapper =

--- a/src/components/page-types/membershipFormPage/MembershipCard.styles.js
+++ b/src/components/page-types/membershipFormPage/MembershipCard.styles.js
@@ -1,14 +1,7 @@
-import { dcnb } from 'cnbuilder';
-
 export const root =
   'su-group su-relative su-overflow-hidden su-bg-saa-black-dark su-break-words su-border-black su-w-full sm:su-max-w-[42rem] md:su-max-w-full';
-export const membershipCardWrapper = (newContact, isSelected) => {
-  dcnb(
-    'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-rounded su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue',
-    newContact && 'su-border-dashed',
-    isSelected && 'su-bg-saa-black su-border-solid'
-  );
-};
+export const membershipCardWrapper =
+  'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-rounded su-border su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue';
 export const initialAndSelectionWrapper =
   'su-flex-col lg:su-flex-row su-items-center su-gap-xs su-relative';
 export const initialWrapper =

--- a/src/components/page-types/membershipFormPage/MembershipCard.styles.js
+++ b/src/components/page-types/membershipFormPage/MembershipCard.styles.js
@@ -4,7 +4,7 @@ export const root =
   'su-group su-relative su-overflow-hidden su-bg-saa-black-dark su-break-words su-border-black su-w-full sm:su-max-w-[42rem] md:su-max-w-full';
 export const membershipCardWrapper = (newContact, isSelected) => {
   dcnb(
-    'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue',
+    'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-rounded su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue',
     newContact ? 'su-border-dashed' : 'su-border-solid',
     isSelected && 'su-bg-saa-black su-border-solid'
   );

--- a/src/components/page-types/membershipFormPage/MembershipCard.styles.js
+++ b/src/components/page-types/membershipFormPage/MembershipCard.styles.js
@@ -5,7 +5,7 @@ export const root =
 export const membershipCardWrapper = (newContact, isSelected) => {
   dcnb(
     'su-basefont-23 su-p-30 lg:su-p-36 su-stretch-link su-w-full su-transition-all su-rounded su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue',
-    newContact ? 'su-border-dashed' : 'su-border-solid',
+    newContact && 'su-border-dashed',
     isSelected && 'su-bg-saa-black su-border-solid'
   );
 };

--- a/src/components/page-types/membershipFormPage/membershipCard.js
+++ b/src/components/page-types/membershipFormPage/membershipCard.js
@@ -11,7 +11,6 @@ const MembershipCard = ({
   initial,
   newContact = false,
   memberData,
-  disabled = false,
 }) => {
   const [state, dispatch] = useContext(FormContext);
   const { registrantsData } = state;
@@ -21,7 +20,7 @@ const MembershipCard = ({
 
   const addRelationship = () => {
     dispatch({
-      type: 'addRegistrant',
+      type: 'addSingleRegistrant',
       payload: memberData,
     });
   };
@@ -41,23 +40,13 @@ const MembershipCard = ({
     }
   };
 
-  let newContactWrapper = '';
-
-  if (newContact && isSelected) {
-    newContactWrapper = 'su-bg-saa-black';
-  } else if (newContact) {
-    newContactWrapper = 'su-border-dashed';
-  }
-
   return (
     <FlexBox direction="col" as="article" className={styles.root}>
       <button
         type="button"
         className={dcnb(
-          isSelected
-            ? dcnb('su-bg-saa-black', styles.membershipCardWrapper(disabled))
-            : styles.membershipCardWrapper(disabled),
-          newContactWrapper
+          styles.membershipCardWrapper,
+          newContact && 'su-border-dashed'
         )}
         onClick={toggleRelationship}
       >
@@ -92,7 +81,7 @@ const MembershipCard = ({
               className={
                 isSelected
                   ? styles.membershipCardSelectedLink
-                  : styles.membershipCardLink(disabled)
+                  : styles.membershipCardLink
               }
             >
               Create new <HeroIcon iconType="plus" />
@@ -103,7 +92,7 @@ const MembershipCard = ({
               className={
                 isSelected
                   ? styles.membershipCardSelectedLink
-                  : styles.membershipCardLink(disabled)
+                  : styles.membershipCardLink
               }
             >
               {isSelected ? 'Selected' : 'Select'}

--- a/src/components/page-types/membershipFormPage/membershipCard.js
+++ b/src/components/page-types/membershipFormPage/membershipCard.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { dcnb } from 'cnbuilder';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import { FormContext } from '../../../contexts/FormContext';
@@ -43,7 +44,11 @@ const MembershipCard = ({
     <FlexBox direction="col" as="article" className={styles.root}>
       <button
         type="button"
-        className={styles.membershipCardWrapper(newContact, isSelected)}
+        className={dcnb(
+          styles.membershipCardWrapper,
+          newContact && 'su-border-dashed',
+          isSelected && newContact ? 'su-bg-saa-black' : ''
+        )}
         onClick={toggleRelationship}
       >
         <FlexBox

--- a/src/components/page-types/membershipFormPage/membershipCard.js
+++ b/src/components/page-types/membershipFormPage/membershipCard.js
@@ -46,8 +46,8 @@ const MembershipCard = ({
         type="button"
         className={dcnb(
           styles.membershipCardWrapper,
-          newContact && 'su-border-dashed',
-          isSelected && newContact ? 'su-bg-saa-black' : ''
+          newContact && !isSelected && 'su-border-dashed',
+          isSelected && 'su-bg-saa-black'
         )}
         onClick={toggleRelationship}
       >

--- a/src/components/page-types/membershipFormPage/membershipCard.js
+++ b/src/components/page-types/membershipFormPage/membershipCard.js
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { dcnb } from 'cnbuilder';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import { FormContext } from '../../../contexts/FormContext';
@@ -44,10 +43,7 @@ const MembershipCard = ({
     <FlexBox direction="col" as="article" className={styles.root}>
       <button
         type="button"
-        className={dcnb(
-          styles.membershipCardWrapper,
-          newContact && 'su-border-dashed'
-        )}
+        className={styles.membershipCardWrapper(newContact, isSelected)}
         onClick={toggleRelationship}
       >
         <FlexBox

--- a/src/components/page-types/membershipFormPage/membershipPaymentCard.js
+++ b/src/components/page-types/membershipFormPage/membershipPaymentCard.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import * as styles from './MembershipCard.styles';
@@ -15,7 +15,7 @@ const MembershipPaymentCard = ({
   <FlexBox direction="col" as="article" className={styles.root}>
     <button
       type="button"
-      className={styles.membershipCardWrapper(false)}
+      className={styles.membershipCardWrapper}
       onClick={() => onClick(id)}
     >
       {isSelected && (
@@ -39,7 +39,7 @@ const MembershipPaymentCard = ({
           className={
             isSelected
               ? styles.membershipCardSelectedLink
-              : styles.membershipCardLink(false)
+              : styles.membershipCardLink
           }
         >
           {isSelected ? 'Selected' : 'Select'}

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -55,6 +55,7 @@ const RelatedContactSelection = (props) => {
       data = {
         // @TODO: Should su_did be the related contact or the registering user's encodedSUID?
         su_did: relationship?.relatedContactEncodedID,
+        su_dname: relationship?.relatedContactDigitalName,
         su_first_name:
           relationship?.relatedContactFullNameParsed?.relatedContactFirstName,
         su_last_name:

--- a/src/components/page-types/membershipFormPage/typeOfRegistrant.js
+++ b/src/components/page-types/membershipFormPage/typeOfRegistrant.js
@@ -105,6 +105,7 @@ const TypeOfRegistrant = (props) => {
                     value[0].registrantsData[0]?.su_reg_type === 'newContact'
                   ) {
                     nextPageLink = '/membership/register/related-contacts';
+                    setPaymentType(false);
                   }
                   if (paymentType === 'installments') {
                     nextPageLink = '/membership/register/installments/form';

--- a/src/components/page-types/membershipFormPage/typeOfRegistrant.js
+++ b/src/components/page-types/membershipFormPage/typeOfRegistrant.js
@@ -47,7 +47,7 @@ const TypeOfRegistrant = (props) => {
   const primaryUser = {
     su_did: userProfile?.session?.encodedSUID,
     su_dname:
-      userProfile.name.digtalName ||
+      userProfile?.name?.digtalName ||
       `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`,
     su_first_name:
       userProfile?.name?.fullNameParsed?.firstName ||

--- a/src/components/page-types/membershipFormPage/typeOfRegistrant.js
+++ b/src/components/page-types/membershipFormPage/typeOfRegistrant.js
@@ -96,8 +96,20 @@ const TypeOfRegistrant = (props) => {
               </div>
               <FormContext.Consumer>
                 {(value) => {
-                  const isContactSelected =
-                    value[0].registrantsData.length === 0;
+                  const isContactSelected = () => {
+                    if (
+                      value[0].registrantsData[0]?.su_reg_type === 'self' &&
+                      paymentType
+                    ) {
+                      return true;
+                    }
+                    if (
+                      value[0].registrantsData[0]?.su_reg_type === 'newContact'
+                    ) {
+                      return true;
+                    }
+                    return false;
+                  };
 
                   let nextPageLink = '/membership/register/form';
 
@@ -206,7 +218,7 @@ const TypeOfRegistrant = (props) => {
                           <FlexBox justifyContent="center">
                             <Link
                               to={nextPageLink}
-                              className={styles.nextLink(isContactSelected)}
+                              className={styles.nextLink(!isContactSelected())}
                               state={{ registrant: value[0].registrantsData }}
                             >
                               Select membership type

--- a/src/components/page-types/membershipFormPage/typeOfRegistrant.js
+++ b/src/components/page-types/membershipFormPage/typeOfRegistrant.js
@@ -46,6 +46,9 @@ const TypeOfRegistrant = (props) => {
 
   const primaryUser = {
     su_did: userProfile?.session?.encodedSUID,
+    su_dname:
+      userProfile.name.digtalName ||
+      `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`,
     su_first_name:
       userProfile?.name?.fullNameParsed?.firstName ||
       userProfile?.session?.firstName,
@@ -150,11 +153,6 @@ const TypeOfRegistrant = (props) => {
                                 subheading={`${primaryUser.su_first_name} ${primaryUser.su_last_name}`}
                                 initial={primaryUser.su_first_name.slice(0, 1)}
                                 memberData={primaryUser}
-                                disabled={
-                                  value[0].registrantsData.length !== 0 &&
-                                  value[0].registrantsData[0]?.su_did !==
-                                    primaryUser.su_did
-                                }
                               />
                             </GridCell>
                             <GridCell xs={12} md={6}>
@@ -163,11 +161,6 @@ const TypeOfRegistrant = (props) => {
                                 subheading="Existing contact or new contact"
                                 initial="?"
                                 memberData={newContact}
-                                disabled={
-                                  value[0].registrantsData.length !== 0 &&
-                                  value[0].registrantsData[0]?.su_did !==
-                                    newContact.su_did
-                                }
                               />
                             </GridCell>
                           </Grid>

--- a/src/contexts/FormContext.js
+++ b/src/contexts/FormContext.js
@@ -18,6 +18,10 @@ function formReducer(state, action) {
           (traveler) => traveler.su_did !== action.payload
         ),
       };
+    case 'addSingleRegistrant':
+      return {
+        registrantsData: [action.payload],
+      };
     default:
       return state;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- update select ux 
- update membership card styling
- add digitalName

# Review By (Date)
- when possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [`membership/register`](https://deploy-preview-568--stanford-alumni.netlify.app/membership/register)
2. Verify that you are able to select between the two type of registrants without having to unselect one before selecting the other
3. Navigate to [`membership/register/related-contacts`](https://deploy-preview-568--stanford-alumni.netlify.app/membership/register/related-contacts)
4. Verify that the new contact styling still appears as expected
5. Select a registrant and continue to the form
6. Confirm that the digital name now displays:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/34019925/214669741-89bbbeeb-92f8-4ccd-9b61-1bdda2186bcd.png">
7. Review code (confirm that disable styling has been removed) 👾 

# Associated Issues and/or People
- ADAPTSM-118
- ADAPTSM-120