### PR TITLE
ADAPTSM-40 | @jdwjdwjdw | exclude membership pages from sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -109,7 +109,7 @@ module.exports = {
             // Exlude form and registration form pages
             page.pageContext.story.content.includes('formPage') ||
             page.pageContext.story.content.includes('registrationFormPage') ||
-            // page.pageContext.story.content.includes('membershipFormPage') ||
+            page.pageContext.story.content.includes('membershipFormPage') ||
             // Exclude pages marked with "noindex"
             page.pageContext.noIndex ||
             // Exclude pages that match the "excludes" array. (default condition)

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -106,7 +106,7 @@ module.exports = {
           if (
             // Exclude non-canonical pages.
             !page.pageContext.isCanonical ||
-            // Exlude form and registration form pages
+            // Exlude form, registration form, and membership form pages
             page.pageContext.story.content.includes('formPage') ||
             page.pageContext.story.content.includes('registrationFormPage') ||
             page.pageContext.story.content.includes('membershipFormPage') ||

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -109,6 +109,7 @@ module.exports = {
             // Exlude form and registration form pages
             page.pageContext.story.content.includes('formPage') ||
             page.pageContext.story.content.includes('registrationFormPage') ||
+            // page.pageContext.story.content.includes('membershipFormPage') ||
             // Exclude pages marked with "noindex"
             page.pageContext.noIndex ||
             // Exclude pages that match the "excludes" array. (default condition)


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [ADAPTSM-40](https://stanfordits.atlassian.net/browse/ADAPTSM-40): DEV | Confirm that the membership pages are excluded from site-map.xml
- Membership form pages included in the sitemap prior to this update:
<img width="872" alt="Screen Shot 2023-01-25 at 11 18 38 AM" src="https://user-images.githubusercontent.com/49299083/214679529-fba9f3ee-08cd-4b9d-8fbf-88dd5d52cb58.png">
- See https://deploy-preview-571--stanford-alumni.netlify.app/sitemap/sitemap-0.xml for updated sitemap

# Review By (Date)
- When convenient

# Review Tasks

## Setup tasks and/or behavior to test

1. Review preview sitemap at https://deploy-preview-571--stanford-alumni.netlify.app/sitemap/sitemap-0.xml and confirm membership pages we want removed have been removed
2. Review code 🔢 

[ADAPTSM-40]: https://stanfordits.atlassian.net/browse/ADAPTSM-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ