### PR TITLE
ADAPTSM-28 | @jdwjdwjdw | style gg form fields

### DIFF
--- a/src/assets/check-mark.svg
+++ b/src/assets/check-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+</svg>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -318,102 +318,6 @@
   opacity: 0.4;
 }
 
-/* GG Checkbox */
-.ggeWidget .ggePrompt .ggePrompt__checkbox {
-  @apply su-relative su-mr-[1.2rem];
-}
-
-/* .ggeWidget .ggePrompt label {
-  @apply su-w-auto su-p-0;
-} */
-
-.ggeWidget .ggePrompt .ggePrompt__checkbox input {
-  @apply su-flex su-w-[2.4rem] su-h-[2.4rem] su-ml-0 su-mb-0 su-rounded-l su-rounded-r su-border-2 su-border-transparent su-bg-saa-electric-blue-light;
-  /* background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
-    border-box; */
-  -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-}
-
-.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox input {
-  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
-    border-box;
-}
-
-.ggeWidget .ggePrompt .ggePrompt__checkbox input:hover {
-  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
-    border-box;
-}
-
-/* .ggeWidget .ggePrompt__other {
-  @apply su-flex su-flex-col;
-} */
-
-/* .ggeWidget .ggePrompt__other .ggePrompt:first-of-type {
-  @apply su-m-0;
-} */
-
-/* .ggeWidget .ggePrompt__other .ggePrompt input[type="text"] {
-  @apply su-ml-[24px];
-} */
-
-.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox::after
-/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::after  */
-{
-  @apply su-absolute su-top-1/2 su-left-1/2 su-flex su-w-[2rem] su-h-[2rem] su--translate-y-1/2 su--translate-x-1/2 su-pointer-events-none;
-  content: "";
-  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
-  mask: url("../assets/check-mark.svg");
-  -webkit-mask-size: contain;
-}
-
-.ggePrompt__checkbox:hover::before {
-  content: "";
-  @apply su-absolute su-inset-[-.6rem] su-rounded-full su-bg-saa-electric-blue-light/[.4];
-}
-
-.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox:hover::before
-/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::before  */
-{
-  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
-  opacity: 0.4;
-}
-
-/* Membership display none */
-.ggeWidget .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
-.ggeWidget .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientLastName__ggid1"],
-.ggeWidget .ggeQuestion .ggeQuestion__label label[for="Terms and Conditions Acknowledgement|I agree.__input__ggid1"],
-.ggeWidget .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."] {
-  @apply su-hidden;
-}
-
-.ggeWidget .ggeQuestion--readonly[data-name="RecipientFirstName"] {
-  @apply su-float-left;
-}
-
-/* Membership registration leave a comment */
-.ggeWidget .ggeQuestion[data-name="Comments"] .ggeQuestion__label {
-  @apply su-clear-both;
-}
-.ggeWidget .ggeQuestion[data-name="Comments"] .ggeQuestion__label label[for="Comments__ggid1"] {
-  @apply su-font-semibold;
-}
-
-/* Membership registration terms & conditions */
-.ggeWidget .ggeQuestion.ggeQuestion--instructions #TermsandConditions {
-  @apply su-font-semibold su-text-white su-type-0;
-}
-.ggeWidget .ggeQuestion.ggeQuestion--instructions #TermsandConditions a {
-  @apply hocus:su-underline su-text-digital-red-light hocus:su-text-digital-red hocus:su-decoration-digital-red;
-}
-.ggeWidget .ggeQuestion.ggeQuestion--instructions #TermsandConditions a::after {
-  @apply su-hidden;
-}
-div[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
-  @apply su-items-center;
-  flex-direction: row !important;
-}
 
 /* Email Other Type */
 .ggeWidget .ggeQuestion.su-email-type .ggePrompt__label label {
@@ -426,13 +330,13 @@ div[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
     140.61deg,
     rgba(24, 29, 28, 0.64) 0%,
     rgba(24, 29, 28, 0.4) 110.98%
-  );
-  border-image-source: linear-gradient(
-    140.61deg,
+    );
+    border-image-source: linear-gradient(
+      140.61deg,
     rgba(255, 255, 255, 0.5) 0%,
     rgba(255, 255, 255, 0) 53.2%,
     rgba(255, 255, 255, 0.5) 109.83%
-  );
+    );
 }
 
 .ggeWidget .ggeContent .ggeQuestion.su-phone,
@@ -575,8 +479,8 @@ div[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
 }
 
 .ggeWidget.ggeWidget--highlightIncomplete
-  .ggeRegistrant--prefilled
-  .ggeQuestion--incomplete {
+.ggeRegistrant--prefilled
+.ggeQuestion--incomplete {
   @apply su-bg-transparent;
 }
 
@@ -691,4 +595,107 @@ div[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
 .ggeWidget .ggeStripeContainer__lowerHr__outer,
 .ggeWidget .ggeStripeContainer__lowerHr__outer .ggeStripeContainer__lowerHr__inner {
   @apply su-bg-transparent;
+}
+
+/* GG Checkbox */
+.ggeWidget .ggePrompt .ggePrompt__checkbox,
+.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field {
+  @apply su-relative su-mr-[1.2rem];
+}
+
+/* .ggeWidget .ggePrompt label {
+  @apply su-w-auto su-p-0;
+} */
+
+.ggeWidget .ggePrompt .ggePrompt__checkbox input,
+.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field input {
+  @apply su-flex su-w-[2.4rem] su-h-[2.4rem] su-ml-0 su-mb-0 su-rounded-l su-rounded-r su-border-2 su-border-transparent su-bg-saa-electric-blue-light;
+  /* background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
+    border-box; */
+  -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+}
+
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox input,
+.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field input:checked {
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
+    border-box;
+}
+
+.ggeWidget .ggePrompt .ggePrompt__checkbox input:hover,
+.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field input:hover {
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
+    border-box;
+}
+
+/* .ggeWidget .ggePrompt__other {
+  @apply su-flex su-flex-col;
+} */
+
+/* .ggeWidget .ggePrompt__other .ggePrompt:first-of-type {
+  @apply su-m-0;
+} */
+
+/* .ggeWidget .ggePrompt__other .ggePrompt input[type="text"] {
+  @apply su-ml-[24px];
+} */
+
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox::after
+/* .ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field::after */
+/* .ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field::after input:checked */
+/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::after  */
+{
+  @apply su-absolute su-top-1/2 su-left-1/2 su-flex su-w-[2rem] su-h-[2rem] su--translate-y-1/2 su--translate-x-1/2 su-pointer-events-none;
+  content: "";
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
+  mask: url("../assets/check-mark.svg");
+  -webkit-mask-size: contain;
+}
+
+.ggePrompt__checkbox:hover::before {
+  content: "";
+  @apply su-absolute su-inset-[-.6rem] su-rounded-full su-bg-saa-electric-blue-light/[.4];
+}
+
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox:hover::before
+/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::before  */
+{
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
+  opacity: 0.4;
+}
+
+/* Membership display none */
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientLastName__ggid1"],
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__label label[for="Terms and Conditions Acknowledgement|I agree.__input__ggid1"],
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."] {
+  @apply su-hidden;
+}
+
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly[data-name="RecipientFirstName"] {
+  @apply su-float-left;
+}
+
+/* Membership registration leave a comment */
+.ggeWidget .ggeQuestion[data-name="Comments"] .ggeQuestion__label {
+  @apply su-clear-both;
+}
+.ggeWidget .ggeQuestion[data-name="Comments"] .ggeQuestion__label label[for="Comments__ggid1"] {
+  @apply su-font-semibold;
+}
+
+/* Membership registration terms & conditions */
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion.ggeQuestion--instructions #TermsandConditions {
+  @apply su-font-semibold su-text-white su-type-0;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion.ggeQuestion--instructions #TermsandConditions a {
+  @apply hocus:su-underline su-text-digital-red-light hocus:su-text-digital-red hocus:su-decoration-digital-red;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion.ggeQuestion--instructions #TermsandConditions a::after {
+  @apply su-hidden;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--acknowledgment.su-terms-and-conditions-check[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
+  @apply su-items-center;
+  flex-direction: row !important;
 }

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -669,12 +669,22 @@
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientLastName__ggid1"],
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__label label[for="Terms and Conditions Acknowledgement|I agree.__input__ggid1"],
-.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."] {
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."],
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field #ggeQuestion__caption--1--PhoneNumber,
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field #ggeQuestion__caption--1--ContactEmail {
   @apply su-hidden;
 }
 
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly[data-name="RecipientFirstName"] {
   @apply su-float-left;
+}
+
+/* Email and Phone Number */
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion[data-name="ContactEmail"] {
+  @apply su-rs-mb-neg2 su-rs-mt-3;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion[data-name="PhoneNumber"] {
+  @apply su-rs-mb-neg2;
 }
 
 /* Membership registration leave a comment */
@@ -707,6 +717,9 @@
 .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt__price::before {
   @apply su-hidden;
 }
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt__price {
+  @apply su-rs-ml-1;
+}
 .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt {
   @apply su-items-start;
 }
@@ -722,9 +735,3 @@
 .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption div {
   @apply su-mt-02em;
 }
-/* .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption i {
-  @apply su-block su-w-10/12 su-leading-display;
-} */
-/* .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption div b {
-  @apply su-leading-display;
-} */

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -603,49 +603,24 @@
   @apply su-relative su-mr-[1.2rem];
 }
 
-/* .ggeWidget .ggePrompt label {
-  @apply su-w-auto su-p-0;
-} */
-
-.ggeWidget .ggePrompt .ggePrompt__checkbox input,
-.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field input {
+.ggeWidget .ggePrompt .ggePrompt__checkbox input {
   @apply su-flex su-w-[2.4rem] su-h-[2.4rem] su-ml-0 su-mb-0 su-rounded-l su-rounded-r su-border-2 su-border-transparent su-bg-saa-electric-blue-light;
-  /* background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
-    border-box; */
   -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
 }
 
-.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox input,
-.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field input:checked {
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox input {
   background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
     border-box;
 }
 
-.ggeWidget .ggePrompt .ggePrompt__checkbox input:hover,
-.ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field input:hover {
+.ggeWidget .ggePrompt .ggePrompt__checkbox input:hover {
   background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
     border-box;
 }
 
-/* .ggeWidget .ggePrompt__other {
-  @apply su-flex su-flex-col;
-} */
-
-/* .ggeWidget .ggePrompt__other .ggePrompt:first-of-type {
-  @apply su-m-0;
-} */
-
-/* .ggeWidget .ggePrompt__other .ggePrompt input[type="text"] {
-  @apply su-ml-[24px];
-} */
-
-.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox::after
-/* .ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field::after */
-/* .ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field::after input:checked */
-/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::after  */
-{
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox::after {
   @apply su-absolute su-top-1/2 su-left-1/2 su-flex su-w-[2rem] su-h-[2rem] su--translate-y-1/2 su--translate-x-1/2 su-pointer-events-none;
   content: "";
   background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
@@ -658,9 +633,7 @@
   @apply su-absolute su-inset-[-.6rem] su-rounded-full su-bg-saa-electric-blue-light/[.4];
 }
 
-.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox:hover::before
-/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::before  */
-{
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox:hover::before {
   background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
   opacity: 0.4;
 }

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -695,7 +695,36 @@
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion.ggeQuestion--instructions #TermsandConditions a::after {
   @apply su-hidden;
 }
-.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--acknowledgment.su-terms-and-conditions-check[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--instructions.su-terms-and-conditions {
+  @apply su-rs-mb-1;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field {
   @apply su-items-center;
   flex-direction: row !important;
 }
+
+/* Membership selection section */
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt__price::before {
+  @apply su-hidden;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt {
+  @apply su-items-start;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label {
+  @apply su-w-full;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label label {
+  @apply su-flex su-justify-between;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption {
+  @apply su-block su-w-10/12 su-leading-display su-ml-0;
+}
+.ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption div {
+  @apply su-mt-02em;
+}
+/* .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption i {
+  @apply su-block su-w-10/12 su-leading-display;
+} */
+/* .ggeWidget.saamembershiptestcampaign .ggeSection--askArray.ggeSection--registration .ggePrompt .ggePrompt__label .ggeQuestion__caption div b {
+  @apply su-leading-display;
+} */

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -318,6 +318,101 @@
   opacity: 0.4;
 }
 
+/* GG Checkbox */
+.ggeWidget .ggePrompt .ggePrompt__checkbox {
+  @apply su-relative su-mr-[1.2rem];
+}
+
+/* .ggeWidget .ggePrompt label {
+  @apply su-w-auto su-p-0;
+} */
+
+.ggeWidget .ggePrompt .ggePrompt__checkbox input {
+  @apply su-flex su-w-[2.4rem] su-h-[2.4rem] su-ml-0 su-mb-0 su-rounded-l su-rounded-r su-border-2 su-border-transparent su-bg-saa-electric-blue-light;
+  /* background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
+    border-box; */
+  -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+}
+
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox input {
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
+    border-box;
+}
+
+.ggeWidget .ggePrompt .ggePrompt__checkbox input:hover {
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%)
+    border-box;
+}
+
+/* .ggeWidget .ggePrompt__other {
+  @apply su-flex su-flex-col;
+} */
+
+/* .ggeWidget .ggePrompt__other .ggePrompt:first-of-type {
+  @apply su-m-0;
+} */
+
+/* .ggeWidget .ggePrompt__other .ggePrompt input[type="text"] {
+  @apply su-ml-[24px];
+} */
+
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox::after
+/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::after  */
+{
+  @apply su-absolute su-top-1/2 su-left-1/2 su-flex su-w-[1.2rem] su-h-[1.2rem] su--translate-y-1/2 su--translate-x-1/2;
+  content: "";
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
+}
+
+.ggePrompt__checkbox:hover::before {
+  content: "";
+  @apply su-absolute su-inset-[-.6rem] su-rounded-full su-bg-saa-electric-blue-light/[.4];
+}
+
+.ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox:hover::before
+/* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::before  */
+{
+  background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
+  opacity: 0.4;
+}
+
+/* Membership display none */
+.ggeWidget .ggeQuestion .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
+.ggeWidget .ggeQuestion .ggeQuestion__label label[for="RecipientLastName__ggid1"],
+.ggeWidget .ggeQuestion .ggeQuestion__label label[for="Terms and Conditions Acknowledgement|I agree.__input__ggid1"],
+.ggeWidget .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."] {
+  @apply su-hidden;
+}
+
+.ggeWidget .ggeQuestion[data-name="RecipientFirstName"] {
+  @apply su-float-left;
+}
+
+/* Membership registration leave a comment */
+.ggeWidget .ggeQuestion[data-name="Comments"] .ggeQuestion__label {
+  @apply su-clear-both;
+}
+.ggeWidget .ggeQuestion[data-name="Comments"] .ggeQuestion__label label[for="Comments__ggid1"] {
+  @apply su-font-semibold;
+}
+
+/* Membership registration terms & conditions */
+.ggeWidget .ggeQuestion.ggeQuestion--instructions #TermsandConditions {
+  @apply su-font-semibold su-text-white su-type-0;
+}
+.ggeWidget .ggeQuestion.ggeQuestion--instructions #TermsandConditions a {
+  @apply hocus:su-underline su-text-digital-red-light hocus:su-text-digital-red hocus:su-decoration-digital-red;
+}
+.ggeWidget .ggeQuestion.ggeQuestion--instructions #TermsandConditions a::after {
+  @apply su-hidden;
+}
+div[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
+  @apply su-items-center;
+  flex-direction: row !important;
+}
+
 /* Email Other Type */
 .ggeWidget .ggeQuestion.su-email-type .ggePrompt__label label {
   @apply su-capitalize;
@@ -348,7 +443,7 @@
   @apply su-flex su-items-baseline;
 }
 .ggeQuestion[data-name="DigitalName"] .ggeQuestion__label {
-  @apply su-text-[2.6rem] su-p-0 su-mr-[.7rem];
+  @apply su-hidden;
 }
 
 .ggeQuestion[data-name="DigitalName"] .ggeQuestion__field input {

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -639,17 +639,11 @@
 }
 
 /* Membership display none */
-.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
-.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientLastName__ggid1"],
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__label label[for="Terms and Conditions Acknowledgement|I agree.__input__ggid1"],
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."],
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field #ggeQuestion__caption--1--PhoneNumber,
 .ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion .ggeQuestion__field #ggeQuestion__caption--1--ContactEmail {
   @apply su-hidden;
-}
-
-.ggeWidget.saamembershiptestcampaign .ggeSection--profile .ggeQuestion--readonly[data-name="RecipientFirstName"] {
-  @apply su-float-left;
 }
 
 /* Email and Phone Number */

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -361,9 +361,11 @@
 .ggeWidget .ggePrompt.ggePrompt--checked .ggePrompt__checkbox::after
 /* .ggeWidget .ggePrompt__other.ggePrompt--checked .ggePrompt:first-of-type .ggePrompt__checkbox::after  */
 {
-  @apply su-absolute su-top-1/2 su-left-1/2 su-flex su-w-[1.2rem] su-h-[1.2rem] su--translate-y-1/2 su--translate-x-1/2;
+  @apply su-absolute su-top-1/2 su-left-1/2 su-flex su-w-[2rem] su-h-[2rem] su--translate-y-1/2 su--translate-x-1/2 su-pointer-events-none;
   content: "";
   background: linear-gradient(222.67deg, #505eec 15.6%, #017e7c 84.05%);
+  mask: url("../assets/check-mark.svg");
+  -webkit-mask-size: contain;
 }
 
 .ggePrompt__checkbox:hover::before {
@@ -379,14 +381,14 @@
 }
 
 /* Membership display none */
-.ggeWidget .ggeQuestion .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
-.ggeWidget .ggeQuestion .ggeQuestion__label label[for="RecipientLastName__ggid1"],
+.ggeWidget .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientFirstName__ggid1"],
+.ggeWidget .ggeQuestion--readonly .ggeQuestion__label label[for="RecipientLastName__ggid1"],
 .ggeWidget .ggeQuestion .ggeQuestion__label label[for="Terms and Conditions Acknowledgement|I agree.__input__ggid1"],
 .ggeWidget .ggeQuestion .ggeQuestion__field textarea[data-fieldid="Terms and Conditions Acknowledgement|I agree."] {
   @apply su-hidden;
 }
 
-.ggeWidget .ggeQuestion[data-name="RecipientFirstName"] {
+.ggeWidget .ggeQuestion--readonly[data-name="RecipientFirstName"] {
   @apply su-float-left;
 }
 
@@ -443,7 +445,7 @@ div[data-name="TermsandConditionsAcknowledgement"] .ggeQuestion__field {
   @apply su-flex su-items-baseline;
 }
 .ggeQuestion[data-name="DigitalName"] .ggeQuestion__label {
-  @apply su-hidden;
+  @apply su-text-[2.6rem] su-p-0 su-mr-[.7rem];
 }
 
 .ggeQuestion[data-name="DigitalName"] .ggeQuestion__field input {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [ADAPTSM-28](https://stanfordits.atlassian.net/browse/ADAPTSM-28): THEME | Style GG form fields
- Additional changes to the Recipient Display name will be completed in [ADAPTSM-146](https://stanfordits.atlassian.net/browse/ADAPTSM-146)
- The terms and conditions checkbox currently looks unstyled, but that should be corrected once the givegab team updates the form structure. Once they have done that, we will review for additional styling in https://stanfordits.atlassian.net/browse/ADAPTSM-145.

# Review By (Date)
- When convenient

# Review Tasks
## Setup tasks and/or behavior to test
1. Check out this branch or view preview at https://deploy-preview-574--stanford-alumni.netlify.app
2. Navigate to [/membership/register](https://deploy-preview-574--stanford-alumni.netlify.app/membership/register) and login as `zguan`
3. Select `Myself` > `Pay in full` > `Select membership type` to navigate to [/membership/register/form](https://deploy-preview-574--stanford-alumni.netlify.app/membership/register/form)
4. Review form styles
5. Review code 🌵

# Associated Issues
- https://stanfordits.atlassian.net/browse/ADAPTSM-145
- https://stanfordits.atlassian.net/browse/ADAPTSM-146

[ADAPTSM-30]: https://stanfordits.atlassian.net/browse/ADAPTSM-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADAPTSM-146]: https://stanfordits.atlassian.net/browse/ADAPTSM-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ADAPTSM-28]: https://stanfordits.atlassian.net/browse/ADAPTSM-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ