### PR TITLE
ADAPTSM-48 | @rebeccahongsf | no merge - test to confirm session data prefills

### DIFF
--- a/src/api/auth/profile.js
+++ b/src/api/auth/profile.js
@@ -15,27 +15,27 @@ const megaprofileHandler = async (req, res, next) => {
   const mp = new MegaProfile();
   const profileId = req.user.encodedSUID;
   const session = req.user;
-  let fullgg = {};
-  let affiliations = [];
+  const fullgg = {};
+  const affiliations = [];
 
   // While the authentication is between states support fetching by both oauth
   // services for the majority of the profile information.
-  try {
-    const fullggresult = await mp.get(`/${profileId}/profiles/fullgg`);
-    fullgg = fullggresult.data;
-  } catch (err) {
-    console.error(err);
-    fullgg.name = {};
-    fullgg.name.digitalName = `${req.user.firstName} ${req.user.lastName}`;
-  }
+  // try {
+  //   const fullggresult = await mp.get(`/${profileId}/profiles/fullgg`);
+  //   fullgg = fullggresult.data;
+  // } catch (err) {
+  //   console.error(err);
+  //   fullgg.name = {};
+  //   fullgg.name.digitalName = `${req.user.firstName} ${req.user.lastName}`;
+  // }
 
-  // // Affiliations is already on the keycloak ouath so we fetch here.
-  try {
-    const mpresult = await mp.get(`/${profileId}/profiles/affiliations`);
-    affiliations = mpresult.data.affiliations;
-  } catch (err) {
-    console.error(err);
-  }
+  // // // Affiliations is already on the keycloak ouath so we fetch here.
+  // try {
+  //   const mpresult = await mp.get(`/${profileId}/profiles/affiliations`);
+  //   affiliations = mpresult.data.affiliations;
+  // } catch (err) {
+  //   console.error(err);
+  // }
 
   const mpUser = { session, ...fullgg, affiliations };
   res.status(200).json(mpUser);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- In the event that the MegaProfile is down, the user session data should be available to prefill name, email, and encodedsuid

# Review By (Date)
- When possible]

# Review Tasks

## Setup tasks and/or behavior to test

1. Login as `zguan` or any test user
2. Navigate to `/api/auth/profile`
3. Confirm that only the session data displays
4. Navigate to `/membership/register`
5. Select `Myself` and `One time payment` then proceed to the form
6. Verify that the digital name and email prefills
7. Navigate back to `/membership/register`
8. Select `Myself` and `Installments` then proceed to the form
9. Verify that the digital name and email prefills
10. Navigate back to `/membership/register`
11. Select `Someone else` and continue to the next page
12. Verify that you land on the form page (since there are no relationships available)
13. Review code 👾 

# Associated Issues and/or People
- ADAPTSM-48