### PR TITLE
ADAPTSM-36 | @rebeccahongsf | add responsive styling for membership form pages

### DIFF
--- a/src/components/page-types/membershipFormPage/membershipFormPage.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.js
@@ -85,9 +85,6 @@ const MembershipFormPage = (props) => {
                   className={styles.formWrapper}
                 >
                   <div className={styles.contentStyle}>
-                    <span className={styles.superHead}>
-                      Stanford Alumni Association Membership
-                    </span>
                     <Heading
                       level={1}
                       size="6"
@@ -95,9 +92,7 @@ const MembershipFormPage = (props) => {
                       font="serif"
                       id="page-title"
                     >
-                      Welcome,{' '}
-                      {userProfile?.name?.fullNameParsed?.firstName ||
-                        userProfile?.session.firstName}
+                      Stanford Alumni Association Membership
                     </Heading>
                   </div>
                   <CreateBloks

--- a/src/components/page-types/membershipFormPage/membershipFormPage.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.js
@@ -15,6 +15,7 @@ import { FormContextProvider } from '../../../contexts/FormContext';
 import AuthContext from '../../../contexts/AuthContext';
 import * as styles from './membershipFormPage.styles';
 import { Heading } from '../../simple/Heading';
+import { FlexBox } from '../../layout/FlexBox';
 
 const MembershipFormPage = (props) => {
   const {
@@ -71,37 +72,34 @@ const MembershipFormPage = (props) => {
                   className={styles.fixedHeroImg}
                 />
               </div>
-              <Grid
-                gap
-                xs={12}
-                className={styles.contentWrapper}
-                id="su-gg-embed"
-              >
-                <GridCell
-                  xs={12}
-                  md={10}
-                  xl={8}
-                  xxl={6}
-                  className={styles.formWrapper}
-                >
-                  <div className={styles.contentStyle}>
-                    <Heading
-                      level={1}
-                      size="6"
-                      align="center"
-                      font="serif"
-                      id="page-title"
-                    >
-                      Stanford Alumni Association Membership
-                    </Heading>
-                  </div>
-                  <CreateBloks
-                    blokSection={giveGabForm}
-                    bgCardStyle="su-bg-saa-black-dark"
-                    urlData={promoCode}
-                  />
-                </GridCell>
-              </Grid>
+              <FlexBox direction="col" className={styles.contentWrapper}>
+                <div className={styles.contentStyle}>
+                  <Heading
+                    level={1}
+                    size="6"
+                    align="center"
+                    font="serif"
+                    id="page-title"
+                  >
+                    Stanford Alumni Association Membership
+                  </Heading>
+                </div>
+                <Grid gap xs={12} id="su-gg-embed">
+                  <GridCell
+                    xs={12}
+                    md={10}
+                    xl={8}
+                    xxl={6}
+                    className={styles.formWrapper}
+                  >
+                    <CreateBloks
+                      blokSection={giveGabForm}
+                      bgCardStyle="su-bg-saa-black-dark"
+                      urlData={promoCode}
+                    />
+                  </GridCell>
+                </Grid>
+              </FlexBox>
               {numAnkle > 0 && <Ankle isDark {...props} />}
             </Container>
           </Layout>

--- a/src/components/page-types/membershipFormPage/membershipFormPage.styles.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.styles.js
@@ -4,7 +4,8 @@ export const fixedHeroImg = 'su-object-cover su-h-full su-w-full';
 export const formWrapper =
   'md:su-col-start-2 xl:su-col-start-3 2xl:su-col-start-4';
 
-export const contentWrapper = 'su-relative su-cc su-z-10 su-rs-pb-8 su-rs-pt-6';
+export const contentWrapper =
+  'su-relative md:su-cc su-z-10 su-rs-pb-8 su-rs-pt-6';
 export const contentStyle = 'su-text-white';
 export const superHead =
   'su-block su-max-w-prose su-font-semibold su-leading-display su-text-shadow-md su-type-2 su-text-center su-mx-auto su-mb-01em';

--- a/src/components/page-types/membershipFormPage/membershipInstallmentsForm.js
+++ b/src/components/page-types/membershipFormPage/membershipInstallmentsForm.js
@@ -15,6 +15,7 @@ import { FormContextProvider } from '../../../contexts/FormContext';
 import AuthContext from '../../../contexts/AuthContext';
 import * as styles from './membershipFormPage.styles';
 import { Heading } from '../../simple/Heading';
+import { FlexBox } from '../../layout/FlexBox';
 
 const MembershipInstallmentsForm = (props) => {
   const {
@@ -71,37 +72,34 @@ const MembershipInstallmentsForm = (props) => {
                   className={styles.fixedHeroImg}
                 />
               </div>
-              <Grid
-                gap
-                xs={12}
-                className={styles.contentWrapper}
-                id="su-gg-embed"
-              >
-                <GridCell
-                  xs={12}
-                  md={10}
-                  xl={8}
-                  xxl={6}
-                  className={styles.formWrapper}
-                >
-                  <div className={styles.contentStyle}>
-                    <Heading
-                      level={1}
-                      size="6"
-                      align="center"
-                      font="serif"
-                      id="page-title"
-                    >
-                      Stanford Alumni Association Membership
-                    </Heading>
-                  </div>
-                  <CreateBloks
-                    blokSection={installmentsForm}
-                    bgCardStyle="su-bg-saa-black-dark"
-                    urlData={promoCode}
-                  />
-                </GridCell>
-              </Grid>
+              <FlexBox direction="col" className={styles.contentWrapper}>
+                <div className={styles.contentStyle}>
+                  <Heading
+                    level={1}
+                    size="6"
+                    align="center"
+                    font="serif"
+                    id="page-title"
+                  >
+                    Stanford Alumni Association Membership
+                  </Heading>
+                </div>
+                <Grid gap xs={12} id="su-gg-embed">
+                  <GridCell
+                    xs={12}
+                    md={10}
+                    xl={8}
+                    xxl={6}
+                    className={styles.formWrapper}
+                  >
+                    <CreateBloks
+                      blokSection={installmentsForm}
+                      bgCardStyle="su-bg-saa-black-dark"
+                      urlData={promoCode}
+                    />
+                  </GridCell>
+                </Grid>
+              </FlexBox>
               {numAnkle > 0 && <Ankle isDark {...props} />}
             </Container>
           </Layout>

--- a/src/components/page-types/membershipFormPage/membershipInstallmentsForm.js
+++ b/src/components/page-types/membershipFormPage/membershipInstallmentsForm.js
@@ -85,9 +85,6 @@ const MembershipInstallmentsForm = (props) => {
                   className={styles.formWrapper}
                 >
                   <div className={styles.contentStyle}>
-                    <span className={styles.superHead}>
-                      Stanford Alumni Association Membership
-                    </span>
                     <Heading
                       level={1}
                       size="6"
@@ -95,9 +92,7 @@ const MembershipInstallmentsForm = (props) => {
                       font="serif"
                       id="page-title"
                     >
-                      Welcome,{' '}
-                      {userProfile?.name?.fullNameParsed?.firstName ||
-                        userProfile?.session.firstName}
+                      Stanford Alumni Association Membership
                     </Heading>
                   </div>
                   <CreateBloks


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- add responsive styling for membership forms

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Login as `zguan`
2. Navigate to [`/membership/register`](https://deploy-preview-581--stanford-alumni.netlify.app/membership/register)
3. Select `Myself` and `One time payment` then continue to form
4. Use inspect browser tool to verify the different breakpoints (xxl, xl, lg, md, sm, xs) with the [Figma mock under components and the GG Payment Pages](https://www.figma.com/file/BfEeWa39C6xT6muvdkBXsw/Membership-2022%2F23?node-id=1200%3A151628&t=kiPibX5XGabdV3Rj-1)
5. Navigate back to [`/membership/register`](https://deploy-preview-581--stanford-alumni.netlify.app/membership/register)
6. Select `Myself` and `Installments` then continue to form
7. Use inspect browser tool to verify the different breakpoints (xxl, xl, lg, md, sm, xs) with the [Figma mock under components and the GG Payment Pages](https://www.figma.com/file/BfEeWa39C6xT6muvdkBXsw/Membership-2022%2F23?node-id=1200%3A151628&t=kiPibX5XGabdV3Rj-1)
8. Review code 👾

**Note:** Both installments and one time payments should display the same in terms of Grid and Title on responsive. These are the GG Payment Pages to compare to:
![image](https://user-images.githubusercontent.com/34019925/218207347-3be6db9a-1708-409b-9806-99d3d64f5489.png)

# Associated Issues and/or People
- ADAPTSM-36