### PR TITLE
ADAPTSM-69 | @rebeccahonsf | accessibility fixup

### DIFF
--- a/src/components/page-types/membershipFormPage/MembershipCard.styles.js
+++ b/src/components/page-types/membershipFormPage/MembershipCard.styles.js
@@ -10,7 +10,6 @@ export const selectionWrapper =
   'sm:su-absolute su-self-end sm:su-self-auto su-right-0 md:su-right-[-20px] lg:su-right-0 su-text-16 su-font-semibold';
 export const checkLinkIcon =
   'su-inline-block su-text-saa-electric-blue su-w-[1.4em] su-mt-[-2px] su-mr-[2px]';
-export const heading = 'su-text-center su-type-2 su-font-bold su-leading';
 export const subheading = 'su-text-center su-type-0 su-rs-mb-1';
 export const membershipCardLink =
   'su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-text-white su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18 su-border-solid su-border-3 su-transition-colors su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-bg-transparent group-hocus:su-text-white group-hocus:su-bg-gradient-to-tr group-hocus:su-from-palo-verde-dark group-hocus:su-to-saa-electric-blue group-hocus:su-shadow-md';

--- a/src/components/page-types/membershipFormPage/membershipCard.js
+++ b/src/components/page-types/membershipFormPage/membershipCard.js
@@ -43,7 +43,7 @@ const MembershipCard = ({
   };
 
   return (
-    <FlexBox direction="col" as="article" className={styles.root}>
+    <FlexBox direction="col" className={styles.root}>
       <button
         type="button"
         className={dcnb(

--- a/src/components/page-types/membershipFormPage/membershipCard.js
+++ b/src/components/page-types/membershipFormPage/membershipCard.js
@@ -4,6 +4,7 @@ import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import { FormContext } from '../../../contexts/FormContext';
 import * as styles from './MembershipCard.styles';
+import { Heading } from '../../simple/Heading';
 
 const MembershipCard = ({
   heading,
@@ -78,8 +79,10 @@ const MembershipCard = ({
             )}
           </FlexBox>
         </FlexBox>
-        <div className={styles.heading}>{heading}</div>
-        <div className={styles.subheading}>{subheading}</div>
+        <Heading level={3} size={2} className="su-mb-0">
+          {heading}
+        </Heading>
+        <p className={styles.subheading}>{subheading}</p>
         <FlexBox justifyContent="center">
           {newContact ? (
             <div

--- a/src/components/page-types/membershipFormPage/membershipFormPage.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.js
@@ -298,9 +298,14 @@ const MembershipFormPage = (props) => {
                           >
                             <div className={styles.paymentInnerWrapper}>
                               <div className={styles.paymentHeadingWrapper}>
-                                <p className={styles.paymentHeading}>
+                                <Heading
+                                  level={2}
+                                  size={2}
+                                  font="serif"
+                                  className="su-mb-0"
+                                >
                                   Payment options
-                                </p>
+                                </Heading>
                                 <p>One time or installments</p>
                               </div>
                               <Grid

--- a/src/components/page-types/membershipFormPage/membershipFormPage.styles.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.styles.js
@@ -35,7 +35,6 @@ export const paymentOuterWrapper = (paymentOptionSection) =>
 export const paymentInnerWrapper =
   'su-rs-mb-3 su-bg-gradient-to-tr su-from-saa-electric-blue-dark su-to-palo-verde-xdark su-rs-px-1 sm:su-rs-px-2 su-rs-pb-5';
 export const paymentHeadingWrapper = 'su-text-center su-rs-pt-4 su-rs-pb-0';
-export const paymentHeading = 'su-type-2 su-font-serif su-font-bold su-mb-0';
 export const paymentCardsWrapper =
   'sm:su-rs-p-2 su-gap-y-xl sm:su-bg-saa-black-dark sm:su-rounded';
 export const promoWrapper = 'su-w-full sm:su-w-auto';

--- a/src/components/page-types/membershipFormPage/membershipPaymentCard.js
+++ b/src/components/page-types/membershipFormPage/membershipPaymentCard.js
@@ -35,7 +35,7 @@ const MembershipPaymentCard = ({
           </div>
         )}
       </FlexBox>
-      <Heading level={3} size={2} className="su-mb-0">
+      <Heading level={3} size={2} className="su-mb-0 su-rs-mt-1">
         {heading}
       </Heading>
       <div className={styles.subheadingAndCaptionWrapper}>

--- a/src/components/page-types/membershipFormPage/membershipPaymentCard.js
+++ b/src/components/page-types/membershipFormPage/membershipPaymentCard.js
@@ -13,7 +13,7 @@ const MembershipPaymentCard = ({
   id,
   isSelected,
 }) => (
-  <FlexBox direction="col" as="article" className={styles.root}>
+  <FlexBox direction="col" className={styles.root}>
     <button
       type="button"
       className={dcnb(

--- a/src/components/page-types/membershipFormPage/membershipPaymentCard.js
+++ b/src/components/page-types/membershipFormPage/membershipPaymentCard.js
@@ -3,6 +3,7 @@ import { dcnb } from 'cnbuilder';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import * as styles from './membershipPaymentCard.styles';
+import { Heading } from '../../simple/Heading';
 
 const MembershipPaymentCard = ({
   heading,
@@ -34,7 +35,9 @@ const MembershipPaymentCard = ({
           </div>
         )}
       </FlexBox>
-      <p className={styles.heading}>{heading}</p>
+      <Heading level={3} size={2} className="su-mb-0">
+        {heading}
+      </Heading>
       <div className={styles.subheadingAndCaptionWrapper}>
         <p className={styles.subheading}>{subheading}</p>
         {caption && <p className={styles.caption}>{caption}</p>}

--- a/src/components/page-types/membershipFormPage/membershipPaymentCard.styles.js
+++ b/src/components/page-types/membershipFormPage/membershipPaymentCard.styles.js
@@ -4,7 +4,6 @@ export const membershipPaymentCardWrapper =
   'su-basefont-23 su-rs-px-3 su-rs-pt-1 su-rs-pb-4 su-stretch-link su-w-full su-transition-all su-rounded su-border su-border-3 su-border-white hocus:su-gradient-border hocus:su-border-to-rt-palo-verde-dark-to-saa-electric-blue focus:su-outline-4 focus:su-outline-offset-4';
 export const initialAndSelectionWrapper =
   'su-flex-col lg:su-flex-row su-items-center su-gap-xs su-relative';
-export const heading = 'su-type-2 su-font-bold su-rs-mt-1 su-mb-0';
 export const subheading = 'su-mb-0';
 export const membershipPaymentCardLink =
   'su-group su-flex su-items-end su-text-18 md:su-text-24 su-font-regular su-no-underline su-text-white su-px-20 su-pt-10 su-pb-11 md:su-px-30 md:su-pt-16 md:su-pb-18 su-border-solid su-border-3 su-transition-colors su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-bg-transparent group-hocus:su-text-white group-hocus:su-bg-gradient-to-tr group-hocus:su-from-palo-verde-dark group-hocus:su-to-saa-electric-blue group-hocus:su-shadow-md';

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -200,15 +200,18 @@
 }
 
 .ggeWidget .ggeStripeBtn,
+.ggeWidget .ggeButton:disabled,
 .ggeWidget .ggeButton {
   @apply su-flex su-leading-none su-inline-block su-w-fit su-no-underline su-underline-offset-[3px] su-font-regular hocus:su-underline su-px-20 su-py-10 md:su-px-26 md:su-py-14 su-text-21 md:su-text-23 su-capitalize su-mt-4 md:su-mt-45 hocus:su-shadow-md;
 }
 
 .ggeWidget .ggeStripeBtn,
+.ggeWidget .ggeButton--forward:disabled,
 .ggeWidget .ggeButton--forward {
   @apply su-border-solid su-border-2 su-pl-[3rem] su-transition-colors su-border-digital-red su-bg-digital-red su-text-white hocus:su-bg-cardinal-red hocus:su-text-white hocus:su-border-cardinal-red su-rounded-none;
 }
 
+.ggeWidget .ggeButton--back:disabled,
 .ggeWidget .ggeButton--back {
   @apply su-static su-border-2 su-pr-[3rem] su-border-solid su-translate-x-0 su-relative su-gradient-border su-border-to-rt-palo-verde-dark-to-saa-electric-blue su-text-saa-electric-blue hocus:su-text-white hocus:su-bg-gradient-to-tr hocus:su-from-palo-verde-dark hocus:su-to-saa-electric-blue hocus:su-shadow-md su-text-white;
 }

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -799,7 +799,7 @@
   @apply su-hidden;
 }
 .ggeWidget.membership-forms .ggeSection--profile .ggeQuestion--instructions.su-terms-and-conditions {
-  @apply su-rs-mb-1;
+  @apply su-rs-mb-1 su-flex su-flex-col su-justify-start su-w-full;
 }
 .ggeWidget.membership-forms .ggeSection--profile .ggeQuestion--acknowledgment.su-terms-and-conditions-check .ggeQuestion__field {
   @apply su-items-center;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- ADAPTSM-69 | fixup button accessibility upon submission
-  ADAPTSM-164 | replace article wrapper with div
- ADAPTSM-165 | fixup headings
- ADAPTSM-166 | fixup terms and conditions

# Review By (Date)
- retro review when possible — I'll most likely roll this into the `membership` branch so I can continue on with the request theming feedback

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [`membership/register`](https://deploy-preview-604--stanford-alumni.netlify.app/membership/register)
2. Inspect the headings structure
```
H1: Page Title
H2: Who do you wish to purchase payment for?
H3: Myself, Someone else
H2: Payment options
H3: Full Payment, Installments
```
3. Inspect Membership Card(s) and confirm that the wrapper around button is a `<div>`
4. Proceed to the form and confirm that the Terms & Conditions appear like the Figma
5. Submit form and verify that the buttons are still visually accessible  
6. Review code and comments 📦 

# Associated Issues and/or People
- ADAPTSM-69
- ADAPTSM-164
- ADAPTSM-165
- ADAPTSM-166