### PR TITLE
ADAPTSM-158 | @rebeccahongsf | configure memberships endpoint

### DIFF
--- a/src/api/auth/profile.js
+++ b/src/api/auth/profile.js
@@ -50,7 +50,7 @@ const megaprofileHandler = async (req, res, next) => {
 
   // Membership Data;
   if (resolved[3].status === 'fulfilled') {
-    memberships = resolved[3].value.data.membership;
+    memberships = resolved[3].value.data.memberships;
   }
 
   const mpUser = {

--- a/src/api/auth/profile.js
+++ b/src/api/auth/profile.js
@@ -19,15 +19,13 @@ const megaprofileHandler = async (req, res, next) => {
   let fullgg = {};
   let affiliations = {};
   let contact = {};
-  // @TODO: Comment back in and test when endpoint is live
-  // let membership = {}
+  let memberships = {};
   // Four simultaneous requests to the API in hopes to stay under 10s.
   const requests = [
     mp.get(`/${profileId}/profiles/fullgg`),
     mp.get(`/${profileId}/profiles/affiliations`),
     mp.get(`/${profileId}/profiles/contact`),
-    // @TODO: Comment back in and test when endpoint is live
-    // mp.get(`/${profileId}/profiles/memberships`),
+    mp.get(`/${profileId}/profiles/memberships`),
   ];
 
   const resolved = await Promise.allSettled(requests);
@@ -50,19 +48,17 @@ const megaprofileHandler = async (req, res, next) => {
     contact = resolved[2].value.data.contact;
   }
 
-  // @TODO: Comment back in and test when endpoint is live
   // Membership Data;
-  // if (resolved[3].status === 'fulfilled') {
-  //   membership = resolved[3].value.data.membership;
-  // }
+  if (resolved[3].status === 'fulfilled') {
+    memberships = resolved[3].value.data.membership;
+  }
 
   const mpUser = {
     session,
     ...fullgg,
     affiliations,
     profilePhotoURL: contact?.profilePhotoURL,
-    // @TODO: Comment back in and test when endpoint is live
-    // membership,
+    memberships,
   };
   res.status(200).json(mpUser);
   next();

--- a/src/components/cards/membershipCard.js
+++ b/src/components/cards/membershipCard.js
@@ -7,10 +7,11 @@ import CreateBloks from '../../utilities/createBloks';
 const MembershipCard = ({ blok: { publicCtaGroup, ctaGroup }, blok }) => {
   const [bgColor, setBgColor] = useState('su-bg-[#C3363A]');
   const [userType, setUserType] = useState(undefined);
-  const [noCard, setNoCard] = useState(false);
+  const [noCard, setNoCard] = useState(true);
   const [bgImage, setBgImage] = useState(null);
   const [exampleImage, setExampleImage] = useState(null);
   const [logo, setLogo] = useState(null);
+  const [membershipNumber, setMembershipNumber] = useState('');
   const auth = useContext(AuthContext);
 
   const fetchImages = async (loggedIn, logoPath, bgPath) => {
@@ -31,10 +32,10 @@ const MembershipCard = ({ blok: { publicCtaGroup, ctaGroup }, blok }) => {
 
   useEffect(() => {
     const memberships = auth.userProfile.memberships || [];
-    setNoCard(true);
     fetchImages(false);
     memberships.forEach((membership) => {
       if (
+        membership.membershipStatus?.includes('Active') &&
         membership.membershipGroup?.includes('SAA') &&
         membership.membershipAffiliation?.includes('Alum')
       ) {
@@ -43,7 +44,10 @@ const MembershipCard = ({ blok: { publicCtaGroup, ctaGroup }, blok }) => {
           'su-bg-gradient-to-b su-from-[#8E1515] su-to-digital-red-light'
         );
         setUserType('saa');
+        setNoCard(false);
+        setMembershipNumber(membership.membershipNumber);
       } else if (
+        membership.membershipStatus?.includes('Active') &&
         membership.membershipGroup?.includes('SAA') &&
         membership.membershipAffiliation?.includes('Affiliate')
       ) {
@@ -52,6 +56,8 @@ const MembershipCard = ({ blok: { publicCtaGroup, ctaGroup }, blok }) => {
           'su-bg-gradient-to-b su-from-illuminating-dark su-to-illuminating-light'
         );
         setUserType('affiliate');
+        setNoCard(false);
+        setMembershipNumber(membership.membershipNumber);
       }
     });
   }, [auth]);
@@ -98,9 +104,7 @@ const MembershipCard = ({ blok: { publicCtaGroup, ctaGroup }, blok }) => {
                           {auth.userProfile?.name?.fullNameParsed?.firstName}{' '}
                           {auth.userProfile?.name?.fullNameParsed?.lastName}
                         </span>
-                        <span>
-                          {auth.userProfile?.membership?.membershipNumber}
-                        </span>
+                        <span>{membershipNumber}</span>
                       </div>
                     </div>
                     <div className="su-absolute su-w-full su-h-full su-top-0 su-right-0">

--- a/src/components/cards/membershipCard.js
+++ b/src/components/cards/membershipCard.js
@@ -30,29 +30,30 @@ const MembershipCard = ({ blok: { publicCtaGroup, ctaGroup }, blok }) => {
   };
 
   useEffect(() => {
-    const membership = auth.userProfile.membership || {};
-    if (
-      membership.membershipGroup?.includes('SAA') &&
-      membership.membershipAffiliation?.includes('Alum')
-    ) {
-      fetchImages(true, 'stanford_alumni-white.png', 'saa-card-bg.png');
-      setBgColor(
-        'su-bg-gradient-to-b su-from-[#8E1515] su-to-digital-red-light'
-      );
-      setUserType('saa');
-    } else if (
-      membership.membershipGroup?.includes('SAA') &&
-      membership.membershipAffiliation?.includes('Affiliate')
-    ) {
-      fetchImages(true, 'stanford_alumni-color.png', 'saa-card-bg.png');
-      setBgColor(
-        'su-bg-gradient-to-b su-from-illuminating-dark su-to-illuminating-light'
-      );
-      setUserType('affiliate');
-    } else {
-      setNoCard(true);
-      fetchImages(false);
-    }
+    const memberships = auth.userProfile.memberships || [];
+    setNoCard(true);
+    fetchImages(false);
+    memberships.forEach((membership) => {
+      if (
+        membership.membershipGroup?.includes('SAA') &&
+        membership.membershipAffiliation?.includes('Alum')
+      ) {
+        fetchImages(true, 'stanford_alumni-white.png', 'saa-card-bg.png');
+        setBgColor(
+          'su-bg-gradient-to-b su-from-[#8E1515] su-to-digital-red-light'
+        );
+        setUserType('saa');
+      } else if (
+        membership.membershipGroup?.includes('SAA') &&
+        membership.membershipAffiliation?.includes('Affiliate')
+      ) {
+        fetchImages(true, 'stanford_alumni-color.png', 'saa-card-bg.png');
+        setBgColor(
+          'su-bg-gradient-to-b su-from-illuminating-dark su-to-illuminating-light'
+        );
+        setUserType('affiliate');
+      }
+    });
   }, [auth]);
 
   return (

--- a/src/utilities/mocks/fullgg.js
+++ b/src/utilities/mocks/fullgg.js
@@ -274,14 +274,14 @@ export const fullggMockData = {
   affiliations: affiliationsMockData,
   memberships: [
     // Test Data for SAA Alum
-    {
-      membershipStatus: 'Active',
-      membershipNumber: '0001223551',
-      membershipType: 'Life',
-      membershipAffiliation: 'Alum',
-      membershipStartDate: '2011',
-      membershipGroup: 'SAA',
-    },
+    // {
+    //   membershipStatus: 'Active',
+    //   membershipNumber: '0001223551',
+    //   membershipType: 'Life',
+    //   membershipAffiliation: 'Alum',
+    //   membershipStartDate: '2011',
+    //   membershipGroup: 'SAA',
+    // },
     //  Test Data for SAA Affiliate
     // {
     //   membershipStatus: 'Active',

--- a/src/utilities/mocks/fullgg.js
+++ b/src/utilities/mocks/fullgg.js
@@ -272,36 +272,34 @@ export const fullggMockData = {
     access_method: 'GET',
   },
   affiliations: affiliationsMockData,
-  membership: {},
-  // Test Data for SAA Alum
-  // membership: {
-  //   id: 'a0046000003s3pnAAA',
-  //   membershipStatus: 'Active',
-  //   membershipNumber: '0001223551',
-  //   membershipType: 'Life',
-  //   membershipAffiliation: 'Alum',
-  //   membershipStartDate: '2011',
-  //   membershipGroup: 'SAA',
-  // },
-  //  Test Data for SAA Affiliate
-  // membership: {
-  //   id: 'a0046000003s3pnAAA',
-  //   membershipStatus: 'Active',
-  //   membershipNumber: '0001223551',
-  //   membershipType: 'Life',
-  //   membershipAffiliation: 'Affiliate',
-  //   membershipStartDate: '2011',
-  //   membershipGroup: 'SAA',
-  // },
-  // Test Data for GSB Membership
-  // membership: {
-  //   id: 'a0046000003s3pnAAA',
-  //   membershipStatus: 'Active',
-  //   membershipNumber: '0001223551',
-  //   membershipType: 'Life',
-  //   membershipAffiliation: 'Alum',
-  //   membershipStartDate: '2011',
-  //   membershipGroup: 'GSB',
-  // },
+  memberships: [
+    // Test Data for SAA Alum
+    {
+      membershipStatus: 'Active',
+      membershipNumber: '0001223551',
+      membershipType: 'Life',
+      membershipAffiliation: 'Alum',
+      membershipStartDate: '2011',
+      membershipGroup: 'SAA',
+    },
+    //  Test Data for SAA Affiliate
+    // {
+    //   membershipStatus: 'Active',
+    //   membershipNumber: '0001223551',
+    //   membershipType: 'Life',
+    //   membershipAffiliation: 'Affiliate',
+    //   membershipStartDate: '2011',
+    //   membershipGroup: 'SAA',
+    // },
+    // Test Data for GSB Membership
+    {
+      membershipStatus: 'Active',
+      membershipNumber: '0001223551',
+      membershipType: 'Life',
+      membershipAffiliation: 'Alum',
+      membershipStartDate: '2011',
+      membershipGroup: 'GSB',
+    },
+  ],
   profilePhotoURL: 'https://placekitten.com/300/300',
 };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- configure memberships endpoint

# Review By (Date)
- asap 🙏 

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [`/membership/saacard` netlify preview](https://deploy-preview-646--stanford-alumni.netlify.app/membership/saacard/)
2. Login as `zguan`
3. Confirm that a sample card appears
4. Check out this branch
5. Add `MEGAPROFILE_MOCK = 'true'` to your `.env`
6. Spin up your local
7. Navigate to `/api/auth/profile`
8. Confirm that the membership mock data appears
*Note: If you encounter a data error (e.g. `Cannot read properties of undefined (reading 'data')`), go to your local `profile.js` file and comment out all lines related to `contact`. That should resolve the issue.
9. Navigate to `/membership/saacard`
10. Login and verify that the red [Alumni card](https://www.figma.com/file/c8Zv388RgBwDcSPtBTZhc1/Digital-Membership-Cards?node-id=0%3A1&t=aXoS3PjQKDtftMto-1) displays.
11. On your local, navigate to `fullgg.js` file and comment out the Alumni data. Comment in the Affiliates data
12. Navigate back to the `/membership/saacard` page and refresh. A yellow card should now appear.
13. On your local, comment out the Affiliate data. Comment in the GSB data
14. Navigate back to the `/membership/saacard` page and refresh. A red sample card should appear.
15. On your local, navigate to `fullgg.js` file and comment in the alumni data so that both GSB and Alumni objs are available
16. Navigate back to the `/membership/saacard` page and refresh. A red alumni card should appear.
17. On your local, navigate to `fullgg.js` file and comment out the alumni data and comment in the affiliations data so that both GSB and Affiliation objs are available
18. Navigate back to the `/membership/saacard` page and refresh. A yellow alumni card should appear.
19. On your local, comment out all the data within memberships. Memberships should now be an empty array (e.g. `memberships: []`)
20. Navigate back to the `/membership/saacard` page and refresh. A red sample card should appear.
21. Review code 🪴 

# Associated Issues and/or People
- ADAPTSM-158