### PR TITLE
ADAPTSM-67 | @rebeccahongsf | set appeal code to always pass into adc val

### DIFF
--- a/src/components/page-types/membershipFormPage/membershipFullPaymentForm.js
+++ b/src/components/page-types/membershipFormPage/membershipFullPaymentForm.js
@@ -45,12 +45,7 @@ const MembershipFullPaymentForm = (props) => {
 
   useEffect(() => {
     window.prefillData = registrant;
-    if (
-      !isAlum(registrant?.su_affiliations) ||
-      registrant?.su_self_membership === 'no'
-    ) {
-      window.appeal_code = promoCode;
-    }
+    window.appeal_code = promoCode;
   }, [registrant, promoCode]);
 
   // In the event that the user goes directly to the related contact page,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- set appeal code to always pass into adc val

# Review By (Date)
- retroreview

# Review Tasks

## Setup tasks and/or behavior to test

1. Login as zguan
2. Navigate to `/membership/register?appeal_code=randomcode`
3. Change the promo code to anything you'd like
4. Proceed to the Myself, full payment form
5. Inspect browser, navigate to console tab, and input `window.su_appeal_code`
6. Confirm that this matches the promo code you entered in
7. Navigate back to `/membership/register?appeal_code=randomcode`
8. Change the promo code to anything you'd like
9. Proceed to the someone else form
10. Inspect browser, navigate to console tab, and input `window.su_appeal_code`
11. Confirm that this matches the promo code you entered in
12. Review code 🤖 

# Associated Issues and/or People
- ADAPTSM-67