### PR TITLE
ADAPTSM-176 | @jdwjdwjdw | Form theme updates

### DIFF
--- a/src/components/page-types/membershipFormPage/membershipInstallmentsForm.js
+++ b/src/components/page-types/membershipFormPage/membershipInstallmentsForm.js
@@ -29,7 +29,7 @@ const MembershipInstallmentsForm = (props) => {
   } = props;
   const numAnkle = getNumBloks(ankleContent);
   const helmetTitle = `Stanford Alumni Association Membership`;
-  const registrant = location?.state?.registrant[0];
+  const registrant = location?.state?.registrant?.[0];
   const promoCode = location?.state?.promoCode;
 
   useEffect(() => {

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -725,11 +725,7 @@
 }
 
 .ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption label[for="ggePaymentPlan--installmentOption__ggid1"] {
-  @apply su-text-18 sm:su-text-21 su-font-semibold;
-}
-
-.ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption label[for="ggePaymentPlan--installmentOption__ggid1"] .ggePaymentPlan--installmentOption__interval {
-  @apply su-mr-5;
+  @apply su-block su-text-18 sm:su-text-21 su-font-semibold;
 }
 
 .ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption .ggeQuestion__caption {

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -675,6 +675,16 @@
 }
 
 
+/* Membership form caption order and text */
+.ggeWidget.membership-forms .ggeQuestion .ggeQuestion__field .ggePrompt__select {
+  @apply su-flex su-flex-col-reverse;
+}
+
+.ggeWidget.membership-forms .ggeQuestion .ggeQuestion__field .ggeQuestion__caption,
+.ggeWidget.membership-forms .ggeQuestion .ggeQuestion__field .ggePrompt__select .ggeQuestion__caption {
+  @apply su-mb-0 su-rs-mt-neg1 su-text-15 md:su-text-18 su-text-black-30;
+}
+
 /* Membership Tally Table */
 .ggeWidget.membership-forms .ggeSection header h1 {
   @apply su-mt-0 su-font-semibold;

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -675,7 +675,7 @@
 }
 
 
-/* Membership form caption order and text */
+/* Membership form caption order, spacing, and styling */
 .ggeWidget.membership-forms .ggeQuestion .ggeQuestion__field .ggePrompt__select {
   @apply su-flex su-flex-col-reverse;
 }
@@ -725,11 +725,15 @@
 }
 
 .ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption label[for="ggePaymentPlan--installmentOption__ggid1"] {
-  @apply su-text-21 su-font-semibold;
+  @apply su-text-18 sm:su-text-21 su-font-semibold;
+}
+
+.ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption label[for="ggePaymentPlan--installmentOption__ggid1"] .ggePaymentPlan--installmentOption__interval {
+  @apply su-mr-5;
 }
 
 .ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption .ggeQuestion__caption {
-  @apply su-text-21;
+  @apply su-text-15 md:su-text-18 su-text-black-30;
 }
 
 .ggeWidget.membership-forms .ggeQuestion.su-membership.su-membership-installment .ggePaymentPlan .ggePrompt--installmentOption.ggePrompt--checked .ggePrompt__radio {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [ADAPTSM-176](https://stanfordits.atlassian.net/browse/ADAPTSM-176): DEV | Form theme updates
- All Optional help text fields on the membership forms should display consistently below the label and above the text field.
  - Can be seen by going to `Someone else` > `Add new contact`
  ![Screen Shot 2023-05-02 at 10 01 31 AM](https://user-images.githubusercontent.com/49299083/235736724-2fb3a800-0cad-42e8-8c10-563b8c7ed022.png)

- On the installments form, first page within the membership options table, there should be a space between “annual” and Membership
![Screen Shot 2023-05-02 at 10 07 28 AM](https://user-images.githubusercontent.com/49299083/235736044-4e3e7573-a4f9-44bb-973e-cc36ca4ffd41.png)
![Screen Shot 2023-05-02 at 9 59 33 AM](https://user-images.githubusercontent.com/49299083/235736101-25806ac4-db29-4457-8ae4-b15b0416aa8f.png)

# Review By (Date)
- When convenient

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch or view preview
2. Login as `carinaw` and navigate to `/membership/register`
3. Select `Someone else` > `Add new contact`, and confirm the captions are being displayed below the label and above the text field
4. Navigate back to `/membership/register`, and select `Myself` > `Pay in installments`
5. Confirm there is spacing between `5 (annual)` and `Membership Installment Plan payments`
6. Review code 🍏 

# Associated Issues and/or People
- [ADAPTSM-176](https://stanfordits.atlassian.net/browse/ADAPTSM-176): DEV | Form theme updates

[ADAPTSM-176]: https://stanfordits.atlassian.net/browse/ADAPTSM-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADAPTSM-176]: https://stanfordits.atlassian.net/browse/ADAPTSM-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ