### PR TITLE
ADAPTSM-74 | @rebeccahongsf | remove basic auth from membership form and card pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,16 +29,6 @@
   [headers.values]
     Basic-Auth = "saa:@lumn1@ss0c1@t10n"
     X-Robots-Tag = "noindex, nofollow"
-[[headers]]
-  for = "/membership/join"
-  [headers.values]
-    Basic-Auth = "saa:membership0n1y23"
-    X-Robots-Tag = "noindex, nofollow"
-[[headers]]
-  for = "/membership/saacard"
-  [headers.values]
-    Basic-Auth = "saa:membership0n1y23"
-    X-Robots-Tag = "noindex, nofollow"
 
 # REDIRECTS
 # ##############################################################################


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- remove basic auth from membership form and card pages

# Review By (Date)
- asap

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [`/membership/join`](https://deploy-preview-675--stanford-alumni.netlify.app/membership/join) and [`/membership/saacard`](https://deploy-preview-675--stanford-alumni.netlify.app/membership/saacard)
2. Verify that you are able to access the page without basic auth
3. Review code

# Associated Issues and/or People
- ADAPTSM-74
