### PR TITLE
DS-387 | @rebeccahongsf | fixup mobile payment not available

### DIFF
--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -693,10 +693,10 @@
 }
 
 /* Travel-Study Payment Button Workaround */
-.ggeWidget:not([class*="membership-forms"]) .ggeStripeContainer {
+.ggeWidget:not([class*="membership-forms"]) div.ggeStripeContainer[role="alert"] {
   @apply su-rs-mb-2 su-rs-pt-1 su-bg-white su-text-black su-rounded;
 }
 
-.ggeWidget:not([class*="membership-forms"]) .ggeStripeContainer__lowerHr {
+.ggeWidget:not([class*="membership-forms"]) div.ggeStripeContainer[role="alert"] .ggeStripeContainer__lowerHr {
   @apply su-p-0;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- further specify styling to not impact mobile payment not available message

# Review By (Date)
- asap

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to https://deploy-preview-727--stanford-alumni.netlify.app/travel-study/destinations/finland-2022/finland-reg-form
2. Verify that the Mobile Payments are not available message does not have a white box
Note: I find that using Chrome where you are logged into your Stanford Account will disable GPay, allow this message to show
![image](https://github.com/SU-SWS/saa_alumni/assets/34019925/5c478541-54a3-4b5c-be0c-6880f67e220a)

3. Review code

# Associated Issues and/or People
- DS-387