### PR TITLE
Adds gradients for breakpoints larger than xs

### DIFF
--- a/src/utilities/dataSource.js
+++ b/src/utilities/dataSource.js
@@ -135,9 +135,9 @@ export const fontWeights = {
 
 export const heroGradient = {
   black: 'su-from-saa-black',
-  brick: 'su-from-brick su-to-brick/30',
-  'palo-alto-dark': 'su-from-palo-alto-dark su-to-palo-alto-dark/30',
-  white: 'su-from-white su-to-white/30',
+  brick: 'xs:su-from-brick su-to-brick/30',
+  'palo-alto-dark': 'xs:su-from-palo-alto-dark su-to-palo-alto-dark/30',
+  white: 'xs:su-from-white su-to-white/30',
 };
 
 export const modularTypes = {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes the hero gradient for larger breakpoints

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to or create a page with a hero component that has an image.
3. Change the Hero Gradient to one of the choices other than Default: Brick, Palo Alto Dark, or White.
4. Verify that:
At the xs breakpoint, the gradient starts at the top with the specified color at 30% opacity and then goes to #181D1C 100% opacity at the bottom.
For all widths larger than xs, the gradient starts at #181D1C 0% opacity at the top and then goes to the specified color 100% opacity at the bottom.

# Associated Issues and/or People
- JIRA ticket: HOM-1
- @William-Misiaszek 

