### PR TITLE
DS-525 | @rebeccahongsf | fix font sizing for promo code input

### DIFF
--- a/src/components/page-types/membershipFormPage/membershipFormPage.styles.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.styles.js
@@ -36,4 +36,4 @@ export const paymentCardsWrapper = 'su-gap-y-xl sm:su-rounded';
 export const promoWrapper = 'su-w-full sm:su-w-auto';
 export const promoLabel = 'su-type-0 su-font-semibold';
 export const promoInput =
-  'sm:su-w-[44rem] su-p-20 su-mt-03em su-rs-mb-2 su-bg-transparent su-rounded su-border su-border-black-30/40 su-border-b-2';
+  'sm:su-w-[44rem] su-p-20 su-mt-03em su-rs-mb-2 su-type-0 su-bg-transparent su-rounded su-border su-border-black-30/40 su-border-b-2';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- fix font sizing for promo code input

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to [dev preview](https://deploy-preview-803--stanford-alumni.netlify.app/membership/join?appeal_code=12345)
2. Verify that the promo code appears in normal font size (compared to [PROD](https://alumni.stanford.edu/membership/join?appeal_code=45243))
3. Review code

# Associated Issues and/or People
- DS-525