### PR TITLE
HSTS set max-age to 31536000

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,7 +17,7 @@
     Content-Security-Policy = "default-src https: 'unsafe-inline' 'unsafe-eval'; form-action https:; img-src https: data:"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Strict-Transport-Security = "max-age=2592000"
+    Strict-Transport-Security = "max-age=31536000"
     Permissions-Policy = "vibrate=(), geolocation=(), midi=(), notifications=(), push=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=()"
     X-Frame-Options = "DENY"
 [[headers]]


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Sets max age to 31536000
- See: https://github.com/SU-SWS/ood_giving_site/pull/402

# Review By (Date)
- End of the month (march)

# Criticality
- low

# Review Tasks

1. Review preview build headers and look for: `Strict-Transport-Security: max-age=31536000;` in the response headers

