### PR TITLE
DS-134: Rework GiveGab Prefill data for T/S and Membership forms

### DIFF
--- a/src/components/page-types/membershipFormPage/membershipFormPage.js
+++ b/src/components/page-types/membershipFormPage/membershipFormPage.js
@@ -9,11 +9,9 @@ import Layout from '../../partials/layout';
 import { HeroImage } from '../../composite/HeroImage/HeroImage';
 import { Grid } from '../../layout/Grid';
 import AuthenticatedPage from '../../auth/AuthenticatedPage';
-import { fetchEmail, fetchPhone } from '../../../utilities/giveGabVars';
 import { GridCell } from '../../layout/GridCell';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
-import Logo from '../../identity/logo';
 import MembershipCard from './membershipCard';
 import AuthContext from '../../../contexts/AuthContext';
 import * as styles from './membershipFormPage.styles';
@@ -23,8 +21,8 @@ import {
 } from '../../../contexts/FormContext';
 import CreateBloks from '../../../utilities/createBloks';
 import MembershipPaymentCard from './membershipPaymentCard';
-import { formatUsDate } from '../../../utilities/transformDate';
 import { isAlum } from '../../../utilities/isAlum';
+import { extractUserData } from '../../../utilities/userProfile';
 import AlumniLogo from '../../../images/stanford_alumni-color.png';
 
 // The type of registrant interstitial page has been set as the default preview within StoryBlok
@@ -75,73 +73,24 @@ const MembershipFormPage = (props) => {
       )
   );
 
-  const emailData = fetchEmail(
-    userProfile?.emails,
-    userProfile?.contact?.preferredEmail
-  );
-
-  const primaryRegistrantEmail = emailData?.email || userProfile?.session.email;
-  const primaryRegistrantEmailType = emailData?.type || null;
-
-  const phoneData = fetchPhone(
-    userProfile?.phoneNumbers,
-    userProfile?.contact?.preferredPhoneType
-  );
-
-  const primaryRegistrantPhoneNumber = phoneData?.phoneNumber
-    ? phoneData.phoneNumber
-    : null;
-  const primaryRegistrantPhoneNumberType = phoneData?.type
-    ? phoneData.type
-    : null;
+  const suUser = extractUserData(userProfile);
 
   const primaryUser = {
-    su_did: userProfile?.session?.encodedSUID,
-    su_dname:
-      userProfile?.contact.name?.digtalName ||
-      `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`,
-    su_first_name:
-      userProfile?.contact.name?.fullNameParsed?.firstName ||
-      userProfile?.session?.firstName,
-    su_last_name:
-      userProfile?.contact.name?.fullNameParsed?.lastName ||
-      userProfile?.session?.lastName,
-    su_email: primaryRegistrantEmail,
-    su_phone: primaryRegistrantPhoneNumber,
-    su_recipient_dob: userProfile?.contact.birthDate
-      ? formatUsDate(userProfile?.contact.birthDate)
-      : '',
-    su_recipient_first_name:
-      userProfile?.contact.name?.fullNameParsed?.firstName ||
-      userProfile?.session?.firstName,
-    su_recipient_last_name:
-      userProfile?.contact.name?.fullNameParsed?.lastName ||
-      userProfile?.session?.lastName,
+    ...suUser,
+    su_recipient_dob: suUser?.su_dob,
+    su_recipient_first_name: suUser?.su_first_name,
+    su_recipient_last_name: suUser?.su_last_name,
     su_recipient_relationship: 'Guest',
-    su_recipient_suid: userProfile?.session?.encodedSUID,
-    su_recipient_email: primaryRegistrantEmail,
-    su_recipient_email_type: primaryRegistrantEmailType || undefined,
-    su_recipient_phone: primaryRegistrantPhoneNumber,
-    su_recipient_phone_type: primaryRegistrantPhoneNumberType || undefined,
+    su_recipient_suid: suUser?.su_did,
+    su_recipient_email: suUser?.su_email,
+    su_recipient_phone: suUser?.su_phone,
     su_self_membership: 'yes',
     su_gift: 'no',
     su_reg_type: 'self',
-    su_affiliations: affiliations,
   };
 
   const newContact = {
-    su_did: userProfile?.session?.encodedSUID,
-    su_dname:
-      userProfile?.contact.name?.digtalName ||
-      `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`,
-    su_first_name:
-      userProfile?.contact.name?.fullNameParsed?.firstName ||
-      userProfile?.session?.firstName,
-    su_last_name:
-      userProfile?.contact.name?.fullNameParsed?.lastName ||
-      userProfile?.session?.lastName,
-    su_email: primaryRegistrantEmail,
-    su_phone: primaryRegistrantPhoneNumber,
+    ...suUser,
     su_reg_type: 'newContact',
     su_self_membership: 'no',
   };

--- a/src/components/page-types/membershipFormPage/relatedContactSelection.js
+++ b/src/components/page-types/membershipFormPage/relatedContactSelection.js
@@ -15,13 +15,13 @@ import * as styles from './relatedContactSelection.styles';
 import { formatUsDate } from '../../../utilities/transformDate';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
-import { fetchEmail, fetchPhone } from '../../../utilities/giveGabVars';
 import MembershipCard from './membershipCard';
 import {
   FormContext,
   FormContextProvider,
 } from '../../../contexts/FormContext';
 import CreateBloks from '../../../utilities/createBloks';
+import { extractUserData } from '../../../utilities/userProfile';
 
 const RelatedContactSelection = (props) => {
   const {
@@ -45,40 +45,14 @@ const RelatedContactSelection = (props) => {
   }
 
   // Map related contacts/relationships data to GiveGab ADC values
-  const emailData = fetchEmail(
-    userProfile?.emails,
-    userProfile?.contact?.preferredEmail
-  );
-
-  const primaryRegistrantEmail = emailData?.email || userProfile?.session.email;
-
-  const phoneData = fetchPhone(
-    userProfile?.phoneNumbers,
-    userProfile?.contact?.preferredPhoneType
-  );
-
-  const primaryRegistrantPhoneNumber = phoneData?.phoneNumber
-    ? phoneData.phoneNumber
-    : null;
-
+  const suUser = extractUserData(userProfile);
   const relationships = userProfile?.relationships;
   const structureRelatedContactData = (relationshipsData = []) => {
     let relatedContacts = [];
     let data = {};
     relationshipsData?.forEach((relationship) => {
       data = {
-        su_did: userProfile?.session?.encodedSUID,
-        su_dname:
-          userProfile?.contact.name?.digtalName ||
-          `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`,
-        su_first_name:
-          userProfile?.contact.name?.fullNameParsed?.firstName ||
-          userProfile?.session?.firstName,
-        su_last_name:
-          userProfile?.contact.name?.fullNameParsed?.lastName ||
-          userProfile?.session?.lastName,
-        su_email: primaryRegistrantEmail,
-        su_phone: primaryRegistrantPhoneNumber,
+        ...suUser,
         su_recipient_dob: relationship?.birthDate
           ? formatUsDate(relationship?.birthDate)
           : '',
@@ -94,7 +68,6 @@ const RelatedContactSelection = (props) => {
         su_recipient_phone_type: undefined,
         su_self_membership: 'no',
         su_gift: 'yes',
-        su_affiliations: userProfile?.affiliations,
       };
       relatedContacts = [...relatedContacts, data];
     });
@@ -103,18 +76,7 @@ const RelatedContactSelection = (props) => {
   const relatedContacts = structureRelatedContactData(relationships);
 
   const newContact = {
-    su_did: userProfile?.session?.encodedSUID,
-    su_dname:
-      userProfile?.contact.name?.digtalName ||
-      `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`,
-    su_first_name:
-      userProfile?.contact.name?.fullNameParsed?.firstName ||
-      userProfile?.session?.firstName,
-    su_last_name:
-      userProfile?.contact.name?.fullNameParsed?.lastName ||
-      userProfile?.session?.lastName,
-    su_email: primaryRegistrantEmail || userProfile?.session?.email,
-    su_phone: primaryRegistrantPhoneNumber,
+    ...suUser,
     su_reg_type: 'newContact',
     su_self_membership: 'no',
   };

--- a/src/components/page-types/registrationFormPage/interstitialPage.js
+++ b/src/components/page-types/registrationFormPage/interstitialPage.js
@@ -18,18 +18,13 @@ import TripPrimaryCard from './tripPrimaryCard';
 import TripTravelerCard from './tripTravelerCard';
 import TripTravelerList from './tripTravelerList';
 import AuthenticatedPage from '../../auth/AuthenticatedPage';
-import {
-  findSelectOption,
-  emailTypeList,
-  phoneNumberTypeList,
-} from './registationFormOptions';
-import { fetchEmail, fetchPhone } from '../../../utilities/giveGabVars';
 import { GridCell } from '../../layout/GridCell';
 import { FlexBox } from '../../layout/FlexBox';
 import HeroIcon from '../../simple/heroIcon';
 import * as styles from './interstitialPage.styles';
 import { formatUsDate } from '../../../utilities/transformDate';
 import { filterRelationships } from '../../../utilities/filterRelationships';
+import { extractUserData } from '../../../utilities/userProfile';
 
 const InterstitialPage = (props) => {
   const {
@@ -99,56 +94,10 @@ const InterstitialPage = (props) => {
     structureTravelerData(relationships)
   );
 
-  const emailData = fetchEmail(
-    userProfile?.emails,
-    userProfile?.contact?.preferredEmail
-  );
-
-  const primaryRegistrantEmail = emailData?.email || userProfile?.session.email;
-  const primaryRegistrantEmailType = emailData?.type || null;
-
-  const phoneData = fetchPhone(
-    userProfile?.phoneNumbers,
-    userProfile?.contact?.preferredPhoneType
-  );
-
-  const primaryRegistrantPhoneNumber = phoneData?.phoneNumber || null;
-  const primaryRegistrantPhoneNumberType = phoneData?.type || null;
-
-  let digitalName;
-  if (userProfile?.contact.name?.digitalName) {
-    digitalName = userProfile?.contact.name?.digitalName;
-  } else if (userProfile?.contact.name?.fullNameParsed?.firstName) {
-    digitalName = `${userProfile?.contact.name?.fullNameParsed?.firstName} ${userProfile?.contact.name?.fullNameParsed?.lastName}`;
-  } else {
-    digitalName = `${userProfile?.session?.firstName} ${userProfile?.session?.lastName}`;
-  }
+  const suUser = extractUserData(userProfile);
 
   const primaryRegistrant = {
-    su_did: userProfile?.session?.encodedSUID,
-    su_dname: digitalName,
-    su_title: userProfile?.contact.name?.fullNameParsed?.prefix,
-    su_first_name:
-      userProfile?.contact.name?.fullNameParsed?.firstName ||
-      userProfile?.session?.firstName,
-    su_middle_name:
-      userProfile?.contact.name?.fullNameParsed?.middleName === null ||
-      userProfile?.contact.name?.fullNameParsed?.middleName === undefined
-        ? '&nbsp;'
-        : userProfile?.contact.name?.fullNameParsed?.middleName,
-    su_last_name:
-      userProfile?.contact.name?.fullNameParsed?.lastName ||
-      userProfile?.session?.lastName,
-    su_email: primaryRegistrantEmail,
-    su_email_type: findSelectOption(emailTypeList, primaryRegistrantEmailType),
-    su_phone: primaryRegistrantPhoneNumber,
-    su_phone_type: findSelectOption(
-      phoneNumberTypeList,
-      primaryRegistrantPhoneNumberType
-    ),
-    su_dob: userProfile?.contact.birthDate
-      ? formatUsDate(userProfile?.contact.birthDate)
-      : undefined,
+    ...suUser,
     su_relation: 'Guest',
     su_reg: 'Primary registrant',
   };

--- a/src/utilities/userProfile.js
+++ b/src/utilities/userProfile.js
@@ -1,0 +1,64 @@
+import { fetchEmail, fetchPhone } from './giveGabVars';
+import { formatUsDate } from './transformDate';
+import {
+  findSelectOption,
+  emailTypeList,
+  phoneNumberTypeList,
+} from '../components/page-types/registrationFormPage/registationFormOptions';
+
+export const extractUserData = (userProfile) => {
+  const emailData = fetchEmail(
+    userProfile?.emails,
+    userProfile?.contact?.preferredEmail
+  );
+
+  const primaryRegistrantEmail = emailData?.email || userProfile?.session.email;
+  const primaryRegistrantEmailType = emailData?.type || null;
+
+  const phoneData = fetchPhone(
+    userProfile?.phoneNumbers,
+    userProfile?.contact?.preferredPhoneType
+  );
+
+  const primaryRegistrantPhoneNumber = phoneData?.phoneNumber || null;
+  const primaryRegistrantPhoneNumberType = phoneData?.type || null;
+
+  const affiliations = userProfile?.affiliation.affiliations || [];
+
+  // Additional user information parsing
+  const firstName =
+    userProfile?.contact.name?.fullNameParsed?.firstName ||
+    userProfile?.session?.firstName;
+  const middleName =
+    userProfile?.contact.name?.fullNameParsed?.middleName === null ||
+    userProfile?.contact.name?.fullNameParsed?.middleName === undefined
+      ? '&nbsp;'
+      : userProfile?.contact.name?.fullNameParsed?.middleName;
+  const lastName =
+    userProfile?.contact.name?.fullNameParsed?.lastName ||
+    userProfile?.session?.lastName;
+  const digitalName =
+    userProfile?.contact.name?.digitalName || `${firstName} ${lastName}`;
+
+  return {
+    su_did: userProfile?.session?.encodedSUID,
+    su_dname: digitalName,
+    su_title: userProfile?.contact.name?.fullNameParsed?.prefix,
+    su_first_name: firstName,
+    su_middle_name: middleName,
+    su_last_name: lastName,
+    su_email: primaryRegistrantEmail,
+    su_email_type: findSelectOption(emailTypeList, primaryRegistrantEmailType),
+    su_recipient_email_type: primaryRegistrantEmailType || undefined,
+    su_phone: primaryRegistrantPhoneNumber,
+    su_phone_type: findSelectOption(
+      phoneNumberTypeList,
+      primaryRegistrantPhoneNumberType
+    ),
+    su_recipient_phone_type: primaryRegistrantPhoneNumberType || undefined,
+    su_dob: userProfile?.contact.birthDate
+      ? formatUsDate(userProfile?.contact.birthDate)
+      : '',
+    su_affiliations: affiliations,
+  };
+};


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Rework GiveGab Prefill data for T/S and Membership forms

# Review By (Date)
- End of sprint

# Criticality
- 3

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to `/travel-study/destinations/china-2024/reserve/form` (or any other T/S form) and make sure everything works as expected
3. Navigate to `/membership/join/form` and make sure `Membership` form works as expected
4. Make sure everything else still works as expected

P.S. I didn't create a new object for the `related contacts` because we are not using the same fields for the `related contacts` object in T/S and Membership forms.