### PR TITLE
DS-582 | @ericbakenhus | Remove duplicate IDs

### DIFF
--- a/src/utilities/sbLink.js
+++ b/src/utilities/sbLink.js
@@ -22,7 +22,6 @@ export const AllowedAnchorAttributes = [
   /^data-.*/,
   /^aria-.*/,
   /^test-.*/,
-  /^id$/,
 ];
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove IDs from links
    - Storyblok passes the UID in the link data's id key (WHY!? They already include it in the `_uid` key!) which we don't want to use as the link's actual id attribute value
    - I didn't see any other duplicate ID issues outside of links (but will check after the next re-scan)

# Review By (Date)
- End of sprint

# Criticality
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Use the [deploy preview](https://deploy-preview-817--stanford-alumni.netlify.app/)
2. Go to any page
3. Inspect any internal link (e.g. in the main nav)
4. Verify that it doesn't have an id attribute
5. For bonus points, run the page through the SiteImprove browser plugin to make sure it doesn't pick up duplicate IDs

# Associated Issues and/or People
- DS-582
