### PR TITLE
DS-583 | @ericbakenhus | Don't render empty links

### DIFF
--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -23,6 +23,11 @@ const RichTextRenderer = ({ wysiwyg, isDark, className, linkColor }) => {
       bold: (children) => <strong>{children}</strong>,
       italic: (children) => <em>{children}</em>,
       link: (children, props) => {
+        if (!children) {
+          // No empty links, please
+          return null;
+        }
+
         const { href, target, linktype } = props;
         if (linktype === 'email') {
           // Email links: add `mailto:` scheme and map to <a>

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactDOM } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer-ts';
 import { dcnb } from 'cnbuilder';
 import { Link } from 'gatsby';
@@ -23,7 +23,7 @@ const RichTextRenderer = ({ wysiwyg, isDark, className, linkColor }) => {
       bold: (children) => <strong>{children}</strong>,
       italic: (children) => <em>{children}</em>,
       link: (children, props) => {
-        if (!children) {
+        if (!children || (typeof children === 'string' && !children.trim())) {
           // No empty links, please
           return null;
         }

--- a/src/utilities/richTextRenderer.js
+++ b/src/utilities/richTextRenderer.js
@@ -1,4 +1,4 @@
-import React, { ReactDOM } from 'react';
+import React from 'react';
 import { render } from 'storyblok-rich-text-react-renderer-ts';
 import { dcnb } from 'cnbuilder';
 import { Link } from 'gatsby';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Prevents empty links in the WYSIWYG editor from rendering (a11y issue)

# Review By (Date)
- End of sprint

# Criticality
- Low

# Review Tasks

## Setup tasks and/or behavior to test

1. See an example of an empty link on the [newsletters page on the dev site](https://dev--stanford-alumni.netlify.app/resources/newsletters/):

![Screenshot 2024-03-13 at 5 54 33 PM](https://github.com/SU-SWS/saa_alumni/assets/1059679/1866848e-6ad7-46a8-8b41-de01dbb65ac0)
<img width="479" alt="Screenshot 2024-03-13 at 4 57 53 PM" src="https://github.com/SU-SWS/saa_alumni/assets/1059679/276106bb-4164-413b-840f-e7fc6d3e2b02">

2. Go the [newsletters page on the deploy preview](https://deploy-preview-819--stanford-alumni.netlify.app/resources/newsletters/)
3. Verify that the empty link no longer appears:

![Screenshot 2024-03-13 at 5 54 38 PM](https://github.com/SU-SWS/saa_alumni/assets/1059679/213f928e-c61e-488b-b7ed-b3b148d73f0e)
![Screenshot 2024-03-13 at 5 49 43 PM](https://github.com/SU-SWS/saa_alumni/assets/1059679/4e0b996f-248b-4227-9d98-159005cf06a2)

# Associated Issues and/or People
- DS-583
