### PR TITLE
DS-615 | @ericbakenhus | Pass search and hash when triggering auth on protected content

### DIFF
--- a/cypress/e2e/1-perks/online-database.cy.ts
+++ b/cypress/e2e/1-perks/online-database.cy.ts
@@ -3,12 +3,12 @@ describe('Perks - Online Databases Page', () => {
     // Login
     cy.login();
 
-    // Visit the online publication databases page
-    cy.visit('/benefits/online-publication-databases/');
+    // Visit the additional payment form page URL
+    cy.visit('/perks/online-databases/');
 
     cy.get('h1').should('contain.text', 'Online Publication Databases');
     cy.get('main').within(() => {
-      cy.get('h3').first().next().should('contain.text', 'We’re sorry, but this benefit is not available for your account.');
+      cy.get('h3').first().should('contain.text', 'I am sorry but your account is not allowed to see this content.');
     })
 
   });

--- a/cypress/e2e/1-perks/online-database.cy.ts
+++ b/cypress/e2e/1-perks/online-database.cy.ts
@@ -3,12 +3,12 @@ describe('Perks - Online Databases Page', () => {
     // Login
     cy.login();
 
-    // Visit the additional payment form page URL
-    cy.visit('/perks/online-databases/');
+    // Visit the online publication databases page
+    cy.visit('/benefits/online-publication-databases/');
 
     cy.get('h1').should('contain.text', 'Online Publication Databases');
     cy.get('main').within(() => {
-      cy.get('h3').first().should('contain.text', 'I am sorry but your account is not allowed to see this content.');
+      cy.get('h3').first().next().should('contain.text', 'We’re sorry, but this benefit is not available for your account.');
     })
 
   });

--- a/netlify/edge-functions/protected-content.js
+++ b/netlify/edge-functions/protected-content.js
@@ -7,8 +7,9 @@ export default async (req, { cookies }) => {
 
   // Redirect to login.
   const url = new URL('/api/auth/login', req.url);
-  const sourceURL = new URL(req.url);
-  url.searchParams.set('final_destination', sourceURL.pathname);
+  const { pathname, search, hash } = new URL(req.url);
+  const finalDestination = `${pathname}${search}${hash}`;
+  url.searchParams.set('final_destination', finalDestination);
   // eslint-disable-next-line consistent-return
   return Response.redirect(url);
 };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Passes any search string and/or hash when auth is triggered when trying to visit a protected page

# Review By (Date)
- ASAP

# Criticality
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Use the [deploy preview](https://deploy-preview-822--stanford-alumni.netlify.app/)
2. Without being logged in, navigate to [/membership/join?appeal_code=45243&test=test#su-promocode](https://deploy-preview-822--stanford-alumni.netlify.app/membership/join?appeal_code=45243&test=test#su-promocode)
3. Log in
4. Verify that the final destination URL contains the search string and hash (`test` and the hash won't actually do anything, just testing that they make it through)
5. Verify that the Promo code input is pre-filled with `45243`

# Associated Issues and/or People
- DS-615
- DS-584