### PR TITLE
DS-644 | @ericbakenhus | Hide footer elements if missing in Storyblok

### DIFF
--- a/src/components/identity/localFooter.js
+++ b/src/components/identity/localFooter.js
@@ -60,7 +60,7 @@ const LocalFooter = ({
                 <div className="su-pb-02em">{address3}</div>
               </address>
               <CreateBloks blokSection={mapLink} />
-              {actionLinks?.length && (
+              {!!actionLinks?.length && (
                 <ul className="su-list-unstyled su-rs-mt-3 su-rs-mb-4 children:su-mb-05em last:children:su-mb-0 children:su-leading-none">
                   <CreateBloks blokSection={actionLinks} as="li" />
                 </ul>
@@ -134,7 +134,7 @@ const LocalFooter = ({
               >
                 <CreateBloks blokSection={linkGroups} />
               </Grid>
-              {legalLinks?.length && (
+              {!!legalLinks?.length && (
                 <nav aria-label="Legal links">
                   <ul className="su-list-unstyled su-link-regular su-divide-x su-divide-white su-text-17 xl:su-text-20 children:su-inline-block children:su-mb-10 children:su-px-1em children:su-leading-display first:children:su-pl-0 last:children:su-pr-0">
                     <CreateBloks blokSection={legalLinks} />

--- a/src/components/identity/localFooter.js
+++ b/src/components/identity/localFooter.js
@@ -67,7 +67,7 @@ const LocalFooter = ({
               )}
               <ul
                 className={`su-flex su-list-unstyled ${
-                  !actionLinks?.length ? 'su-rs-mt-8' : ''
+                  !actionLinks?.length ? 'su-rs-mt-4' : ''
                 }`}
               >
                 <li className="su-mr-1em">

--- a/src/components/identity/localFooter.js
+++ b/src/components/identity/localFooter.js
@@ -60,10 +60,16 @@ const LocalFooter = ({
                 <div className="su-pb-02em">{address3}</div>
               </address>
               <CreateBloks blokSection={mapLink} />
-              <ul className="su-list-unstyled su-rs-mt-3 su-rs-mb-4 children:su-mb-05em last:children:su-mb-0 children:su-leading-none">
-                <CreateBloks blokSection={actionLinks} as="li" />
-              </ul>
-              <ul className="su-flex su-list-unstyled">
+              {actionLinks?.length && (
+                <ul className="su-list-unstyled su-rs-mt-3 su-rs-mb-4 children:su-mb-05em last:children:su-mb-0 children:su-leading-none">
+                  <CreateBloks blokSection={actionLinks} as="li" />
+                </ul>
+              )}
+              <ul
+                className={`su-flex su-list-unstyled ${
+                  !actionLinks?.length ? 'su-rs-mt-8' : ''
+                }`}
+              >
                 <li className="su-mr-1em">
                   <SocialIconLink
                     icon="fa-facebook-f"
@@ -128,11 +134,13 @@ const LocalFooter = ({
               >
                 <CreateBloks blokSection={linkGroups} />
               </Grid>
-              <nav aria-label="Legal links">
-                <ul className="su-list-unstyled su-link-regular su-divide-x su-divide-white su-text-17 xl:su-text-20 children:su-inline-block children:su-mb-10 children:su-px-1em children:su-leading-display first:children:su-pl-0 last:children:su-pr-0">
-                  <CreateBloks blokSection={legalLinks} />
-                </ul>
-              </nav>
+              {legalLinks?.length && (
+                <nav aria-label="Legal links">
+                  <ul className="su-list-unstyled su-link-regular su-divide-x su-divide-white su-text-17 xl:su-text-20 children:su-inline-block children:su-mb-10 children:su-px-1em children:su-leading-display first:children:su-pl-0 last:children:su-pr-0">
+                    <CreateBloks blokSection={legalLinks} />
+                  </ul>
+                </nav>
+              )}
             </GridCell>
           </Grid>
         </Container>

--- a/src/components/navigation/linkGroup.js
+++ b/src/components/navigation/linkGroup.js
@@ -6,14 +6,16 @@ import CreateBloks from '../../utilities/createBloks';
 const LinkGroup = ({ blok: { heading, linkList }, blok }) => (
   <SbEditable content={blok}>
     <div>
-      <Heading
-        level={2}
-        font="serif"
-        tracking="normal"
-        className="su-text-18 su-rs-mb-1"
-      >
-        {heading}
-      </Heading>
+      {heading && (
+        <Heading
+          level={2}
+          font="serif"
+          tracking="normal"
+          className="su-text-18 su-rs-mb-1"
+        >
+          {heading}
+        </Heading>
+      )}
       <ul className="su-list-unstyled su-link-regular su-text-19 xl:su-text-20">
         <CreateBloks blokSection={linkList} />
       </ul>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- There is a new footer in the [prod Alumni](https://alumni.stanford.edu/) that omits expected content causing several empty elements to render
- Hides certain local footer elements if left empty in Storyblok
- NOTE: This is just a quick band aid to handle the a11y issues with the new local footer content and is not meant to suggest a long-term strategy to handle these types of content changes 😅 

# Review By (Date)
- ASAP

# Criticality
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Use the [deploy preview](https://deploy-preview-839--stanford-alumni.netlify.app/)
2. Navigate to the [home page](https://deploy-preview-839--stanford-alumni.netlify.app/) (the dev home page has been altered to use a local footer that is similar to the current prod local footer)
3. Verify the spacing and layout looks similar to the [current prod local footer](https://alumni.stanford.edu/) (the list groups on the right will be higher since there are no longer empty headings)
4. Verify there are no empty elements in the local footer (list group headings on the right, empty `ul`s at the bottom of both the left and right)
5. Verify (manually or through automated tools) that there are no level A a11y issues with the local footer

For example:
![Screenshot 2024-04-22 at 9 27 04 AM](https://github.com/SU-SWS/saa_alumni/assets/1059679/edbd2ac0-d9fe-4ed2-9a9e-eb94ccda491b)


# Associated Issues and/or People
- DS-644