### PR TITLE
DS-654 | @ericbakenhus | Hide empty uls

### DIFF
--- a/src/components/page-types/associatesDirectoryPage/Directory/AssociateList.jsx
+++ b/src/components/page-types/associatesDirectoryPage/Directory/AssociateList.jsx
@@ -24,16 +24,18 @@ const AssociateList = ({ letter, associates, onlyNewMembers, recentYear }) => (
     <h2 className="su-type-2 su-p-10 su-text-cardinal-red-xdark su-font-serif su-border-b su-border-dashed su-border-black-30/40">
       {letter}
     </h2>
-    <ul className="su-p-0 su-list-none">
-      {associates?.map((person, index) => (
-        <Associate
-          // eslint-disable-next-line react/no-array-index-key
-          key={`person-${person.entryTitle}-${index}`}
-          person={person}
-          isEnabled={!onlyNewMembers || person.yearAdded === recentYear}
-        />
-      ))}
-    </ul>
+    {!!associates?.length && (
+      <ul className="su-p-0 su-list-none">
+        {associates.map((person, index) => (
+          <Associate
+            // eslint-disable-next-line react/no-array-index-key
+            key={`person-${person.entryTitle}-${index}`}
+            person={person}
+            isEnabled={!onlyNewMembers || person.yearAdded === recentYear}
+          />
+        ))}
+      </ul>
+    )}
     <BackToTopLink />
   </div>
 );

--- a/src/components/simple/linkList.js
+++ b/src/components/simple/linkList.js
@@ -18,9 +18,11 @@ const LinkList = ({
         {title}
       </Heading>
     )}
-    <ul className="su-list-unstyled children:su-mb-07em children:su-leading-none">
-      <CreateBloks blokSection={links} as="li" />
-    </ul>
+    {!!links?.length && (
+      <ul className="su-list-unstyled children:su-mb-07em children:su-leading-none">
+        <CreateBloks blokSection={links} as="li" />
+      </ul>
+    )}
   </div>
 );
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Hides a couple `ul`s if they're empty.

# Review By (Date)
- Whenever

# Criticality
- Low

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch or use the [deploy preview](https://deploy-preview-842--stanford-alumni.netlify.app/)
2. Navigate to [/groups/identities/](https://deploy-preview-842--stanford-alumni.netlify.app/groups/identities/)
3. Verify there aren't a bunch of empty `ul`s below "Shared Identity" (you can use an a11y tool to check for 1.3.1 issues)

For example (dev site on left, deploy preview on right):
<img width="799" alt="Screenshot 2024-04-29 at 10 39 17 AM" src="https://github.com/SU-SWS/saa_alumni/assets/1059679/0a089a24-5fd9-400b-91c0-a8e3c61ba637">

4. Look at code for the associate list (since we can't really test it easily) and make sure the [page itself](https://deploy-preview-842--stanford-alumni.netlify.app/stanford-associates/directory/) still functions correctly


# Associated Issues and/or People
- DS-654
