### PR TITLE
DS-683, DS-692, DS-693 | @ericbakenhus | Webhook background function

### DIFF
--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -37,11 +37,15 @@ export default async (req: Request) => {
       throw new Error('Wrong signature');
     }
 
+    console.log('Signature fine');
+
     const deployUrl = process.env.DEPLOY_HOOK_URL ?? '';
 
     if (!deployUrl) {
       throw new Error('Missing deploy info');
     }
+
+    console.log({ deployUrl });
 
     const data: SBWebhookPayload = await req.json();
     
@@ -49,6 +53,7 @@ export default async (req: Request) => {
       || data.action === 'merged'
       || data.action === 'deleted'
     ) {
+      console.log('trigger deploy');
       // Trigger rebuild and stop
       await fetch(deployUrl, { method: 'POST' });
       console.log('Deploy triggered');
@@ -62,9 +67,19 @@ export default async (req: Request) => {
       accessToken: process.env.STORYBLOK_ACCESS_TOKEN,
     });
 
+    console.log('sb client created');
+
     const story = await storyblok.getStory(data.full_slug);
+
+    console.log({ story });
+
     const contentType = story.data.story.content.component;
+
+    console.log({ contentType });
+
     const isEvent = contentType === 'synchronizedEvent';
+
+    console.log({ isEvent });
 
     if (!isEvent) {
       // Trigger rebuild and stop

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -35,6 +35,8 @@ export default async (req: Request) => {
     }
 
     const data: SBWebhookPayload = await JSON.parse(rawData);
+
+    console.log({ data });
     
     if (data.action === 'entries_updated'
       || data.action === 'merged'
@@ -49,6 +51,8 @@ export default async (req: Request) => {
 
     // Only pub/unpub actions after this
 
+    console.log({ token: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN });
+
     const storyblok = new StoryblokClient({
       accessToken: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN,
     });
@@ -56,6 +60,8 @@ export default async (req: Request) => {
     const story = await storyblok.getStory(data.full_slug);
     const contentType = story.data.story.content.component;
     const isEvent = contentType === 'synchronizedEvent';
+
+    console.log({ story, contentType, isEvent });
 
     if (!isEvent) {
       // Trigger rebuild and stop

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -110,7 +110,7 @@ export default async (req: Request) => {
     if (data.action === 'published') {
       // Upsert to Algolia (no rebuild)
       await index.saveObject({
-        objectId: storyId,
+        objectID: storyId,
         ...eventData,
       })
       console.log('Algolia upsert: ', storyId);

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -5,13 +5,11 @@ import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookTy
 
 export default async (req: Request) => {
   console.log('=== START Deploy Background Function ===');
-  const signature = req.headers['webhook-signature'] ?? '';
+  const signature = req.headers.get('webhook-signature') ?? '';
   const deployUrl = process.env.DEPLOY_HOOK_URL ?? '';
   const algoliaWriteKey = process.env.ALGOLIA_EVENTS_WRITE_KEY ?? '';
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
-
-  console.log({ sig: req.headers['webhook-signature'], signature });
 
   try {
     if (!signature) {

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -57,8 +57,6 @@ export default async (req: Request) => {
     const contentType = story?.data?.story?.content?.component;
     const isEvent = contentType === 'synchronizedEvent';
 
-    console.log({ version, story, contentType });
-
     if (!isEvent) {
       // Trigger rebuild and stop
       await fetch(deployUrl, { method: 'POST' });
@@ -84,8 +82,6 @@ export default async (req: Request) => {
     const index = client.initIndex(algoliaIndex);
     const storyId = story.data.story.uuid;
     const eventData = story.data.story.content;
-
-    console.log({ storyId, eventData });
 
     if (data.action === 'published') {
       // Upsert to Algolia (no rebuild)

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -35,8 +35,6 @@ export default async (req: Request) => {
     }
 
     const data: SBWebhookPayload = await JSON.parse(rawData);
-
-    console.log({ data });
     
     if (data.action === 'entries_updated'
       || data.action === 'merged'
@@ -51,8 +49,6 @@ export default async (req: Request) => {
 
     // Only pub/unpub actions after this
 
-    console.log({ token: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN });
-
     const storyblok = new StoryblokClient({
       accessToken: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN,
     });
@@ -61,8 +57,6 @@ export default async (req: Request) => {
     const story = await storyblok.getStory(data.full_slug, { version });
     const contentType = story.data.story.content.component;
     const isEvent = contentType === 'synchronizedEvent';
-
-    console.log({ story, contentType, isEvent });
 
     if (!isEvent) {
       // Trigger rebuild and stop

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -1,0 +1,92 @@
+import StoryblokClient from 'storyblok-js-client';
+import algoliasearch from 'algoliasearch';
+import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookType';
+
+export default async (req: Request) => {
+  console.log('=== START Deploy Background Function ===');
+  const signature = req.headers?.['webhook-signature'] ?? '';
+  const deployUrl = process.env.DEPLOY_HOOK ?? '';
+  const algoliaWriteKey = process.env.ALGOLIA_EVENTS_WRITE_KEY ?? '';
+  const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
+  const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
+
+  try {
+    if (!signature) {
+      throw new Error('No signature');
+    }
+
+    if (signature !== process.env.SECRET) {
+      throw new Error('Wrong signature');
+    }
+
+    if (!deployUrl) {
+      throw new Error('Missing deploy info');
+    }
+
+    const data: SBWebhookPayload = await req.json();
+    
+    if (data.action === 'entries_updated' || data.action === 'merged') {
+      // Trigger rebuild and stop
+      await fetch(deployUrl, { method: 'POST' });
+      console.log('Deploy triggered');
+      console.log('=== END Deploy Background Function ===');
+      return;
+    }
+
+    // Only pub/unpub actions after this
+
+    const storyblok = new StoryblokClient({
+      accessToken: process.env.STORYBLOK_ACCESS_TOKEN,
+    });
+
+    const story = await storyblok.getStory(data.full_slug);
+    const contentType = story.data.story.content.component;
+    const isEvent = contentType === 'synchronizedEvent';
+
+    if (!isEvent) {
+      // Trigger rebuild and stop
+      await fetch(deployUrl, { method: 'POST' });
+      console.log('Deploy triggered');
+      console.log('=== END Deploy Background Function ===');
+      return;
+    }
+
+    // Only pub/unpub actions for alumni events
+
+    if (!algoliaAppId || !algoliaWriteKey || !algoliaIndex) {
+      throw new Error('Missing Algolia API info');
+    }
+
+    const client = algoliasearch(
+      algoliaAppId,
+      algoliaWriteKey,
+    );
+    const index = client.initIndex(algoliaIndex);
+    const storyId = story.data.story.uuid;
+    const eventData = story.data.story.content;
+
+    if (data.action === 'published') {
+      // Upsert to Algolia (no rebuild)
+      await index.saveObject({
+        objectId: storyId,
+        ...eventData,
+      })
+      console.log('Algolia upsert: ', storyId);
+      console.log('=== END Deploy Background Function ===');
+      return;
+    }
+
+    if (data.action === 'unpublished') {
+      // Delete from algolia (no rebuild)
+      await index.deleteObject(storyId);
+      console.log('Algolia delete: ', storyId);
+      console.log('=== END Deploy Background Function ===');
+      return;
+    }
+    
+  } catch (err) {
+    console.error('Error during deploy function: ', err);
+  }
+
+  console.log('=== END Deploy Background Function ===');
+};

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -11,9 +11,14 @@ export default async (req: Request) => {
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
 
-  console.log(Netlify.env.toObject());
-
-  console.log(process.env);
+  console.log([
+    process.env.DEPLOY_HOOK_URL,
+    process.env.ALGOLIA_EVENTS_WRITE_KEY,
+    process.env.GATSBY_ALGOLIA_APP_ID,
+    process.env.ALGOLIA_EVENTS_INDEX_NAME,
+    process.env.STORYBLOK_WEBHOOK_SECRET,
+    process.env.STORYBLOK_ACCESS_TOKEN,
+  ]);
 
   try {
     if (!signature) {

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -12,6 +12,7 @@ export default async (req: Request) => {
 
   try {
     const rawData = await req.text();
+    console.log({ rawData });
 
     if (!rawData) {
       throw new Error('No payload');
@@ -24,7 +25,13 @@ export default async (req: Request) => {
     }
 
     const webhookSecret = process.env.STORYBLOK_WEBHOOK_SECRET ?? '';
-    const generatedSignature = createHmac('sha1', webhookSecret).update(rawData).digest('hex');
+    console.log({ webhookSecret });
+    const hmac = createHmac('sha1', webhookSecret);
+    console.log({ hmac });
+    const updatedhmac = hmac.update(rawData);
+    console.log({ updatedhmac });
+    const generatedSignature = updatedhmac.digest('hex');
+    console.log({ generatedSignature });
   
     if (signature !== generatedSignature) {
       throw new Error('Wrong signature');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -6,7 +6,7 @@ import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookTy
 export default async (req: Request) => {
   console.log('=== START Deploy Background Function ===');
   const signature = req.headers?.['webhook-signature'] ?? '';
-  const deployUrl = process.env.DEPLOY_HOOK ?? '';
+  const deployUrl = process.env.DEPLOY_HOOK_URL ?? '';
   const algoliaWriteKey = process.env.ALGOLIA_EVENTS_WRITE_KEY ?? '';
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
@@ -26,7 +26,10 @@ export default async (req: Request) => {
 
     const data: SBWebhookPayload = await req.json();
     
-    if (data.action === 'entries_updated' || data.action === 'merged') {
+    if (data.action === 'entries_updated'
+      || data.action === 'merged'
+      || data.action === 'deleted'
+    ) {
       // Trigger rebuild and stop
       await fetch(deployUrl, { method: 'POST' });
       console.log('Deploy triggered');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -11,6 +11,8 @@ export default async (req: Request) => {
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
 
+  console.log(Netlify.env.toObject());
+
   console.log(process.env);
 
   try {

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -96,5 +96,5 @@ export default async (req: Request) => {
 };
 
 // export const config: Config = {
-//   path: '/api/handle-deploy',
+//   path: '/api-test/handle-deploy',
 // };

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -14,14 +14,10 @@ export default async (req: Request) => {
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
 
-  console.log([
-    process.env.DEPLOY_HOOK_URL,
-    process.env.ALGOLIA_EVENTS_WRITE_KEY,
-    process.env.GATSBY_ALGOLIA_APP_ID,
-    process.env.ALGOLIA_EVENTS_INDEX_NAME,
-    process.env.STORYBLOK_WEBHOOK_SECRET,
-    process.env.STORYBLOK_ACCESS_TOKEN,
-  ]);
+  console.log({
+    knownSecret: process.env.STORYBLOK_WEBHOOK_SECRET,
+    sentSecret: signature,
+  });
 
   try {
     if (!signature) {

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -50,7 +50,7 @@ export default async (req: Request) => {
     // Only pub/unpub actions after this
 
     const storyblok = new StoryblokClient({
-      accessToken: process.env.STORYBLOK_ACCESS_TOKEN,
+      accessToken: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN,
     });
 
     const story = await storyblok.getStory(data.full_slug);
@@ -96,9 +96,6 @@ export default async (req: Request) => {
 
     if (data.action === 'unpublished') {
       // Delete from algolia (no rebuild)
-
-      console.log({ storyId, eventData });
-
       await index.deleteObject(storyId);
       console.log('Algolia delete: ', storyId);
       console.log('=== END Deploy Background Function ===');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -1,4 +1,3 @@
-import { type Config } from '@netlify/functions';
 import dotenv from 'dotenv';
 import { createHmac } from 'node:crypto';
 import StoryblokClient from 'storyblok-js-client';

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -11,6 +11,8 @@ export default async (req: Request) => {
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
 
+  console.log(process.env);
+
   try {
     if (!signature) {
       throw new Error('No signature');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -47,7 +47,7 @@ export default async (req: Request) => {
 
     console.log({ deployUrl });
 
-    const data: SBWebhookPayload = await req.json();
+    const data: SBWebhookPayload = await JSON.parse(rawData);
     
     if (data.action === 'entries_updated'
       || data.action === 'merged'

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -96,6 +96,9 @@ export default async (req: Request) => {
 
     if (data.action === 'unpublished') {
       // Delete from algolia (no rebuild)
+
+      console.log({ storyId, eventData });
+
       await index.deleteObject(storyId);
       console.log('Algolia delete: ', storyId);
       console.log('=== END Deploy Background Function ===');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import { type Config } from '@netlify/functions';
 import { createHmac } from 'node:crypto';
 import StoryblokClient from 'storyblok-js-client';
 import algoliasearch from 'algoliasearch';
@@ -109,4 +110,8 @@ export default async (req: Request) => {
   }
 
   console.log('=== END Deploy Background Function ===');
+};
+
+export const config: Config = {
+  path: '/webhook/sb/deploy',
 };

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -5,6 +5,7 @@ import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookTy
 
 export default async (req: Request) => {
   console.log('=== START Deploy Background Function ===');
+  console.log({ headers: req.headers });
   const signature = req.headers?.['webhook-signature'] ?? '';
   const deployUrl = process.env.DEPLOY_HOOK_URL ?? '';
   const algoliaWriteKey = process.env.ALGOLIA_EVENTS_WRITE_KEY ?? '';

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -57,7 +57,8 @@ export default async (req: Request) => {
       accessToken: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN,
     });
 
-    const story = await storyblok.getStory(data.full_slug);
+    const version = data.action === 'unpublished' ? 'draft' : 'published';
+    const story = await storyblok.getStory(data.full_slug, { version });
     const contentType = story.data.story.content.component;
     const isEvent = contentType === 'synchronizedEvent';
 

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -1,7 +1,10 @@
 import { type Config } from '@netlify/functions';
+import dotenv from 'dotenv';
 import StoryblokClient from 'storyblok-js-client';
 import algoliasearch from 'algoliasearch';
 import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookType';
+
+dotenv.config();
 
 export default async (req: Request) => {
   console.log('=== START Deploy Background Function ===');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -3,6 +3,7 @@ import { createHmac } from 'node:crypto';
 import StoryblokClient from 'storyblok-js-client';
 import algoliasearch from 'algoliasearch';
 import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookType';
+import { mergeEventOverrides } from '../../src/utilities/mergeEventOverrides';
 
 dotenv.config();
 
@@ -88,7 +89,7 @@ export default async (req: Request) => {
       // Upsert to Algolia (no rebuild)
       await index.saveObject({
         objectID: storyId,
-        ...eventData,
+        ...mergeEventOverrides(eventData),
       })
       console.log('Algolia upsert: ', storyId);
       console.log('=== END Deploy Background Function ===');

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -5,12 +5,13 @@ import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookTy
 
 export default async (req: Request) => {
   console.log('=== START Deploy Background Function ===');
-  console.log({ headers: req.headers });
-  const signature = req.headers?.['webhook-signature'] ?? '';
+  const signature = req.headers['webhook-signature'] ?? '';
   const deployUrl = process.env.DEPLOY_HOOK_URL ?? '';
   const algoliaWriteKey = process.env.ALGOLIA_EVENTS_WRITE_KEY ?? '';
   const algoliaAppId = process.env.GATSBY_ALGOLIA_APP_ID ?? '';
   const algoliaIndex = process.env.ALGOLIA_EVENTS_INDEX_NAME ?? '';
+
+  console.log({ sig: req.headers['webhook-signature'], signature });
 
   try {
     if (!signature) {

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -1,3 +1,4 @@
+import { type Config } from '@netlify/functions';
 import StoryblokClient from 'storyblok-js-client';
 import algoliasearch from 'algoliasearch';
 import { type SBWebhookPayload } from '../../src/types/storyblok/api/SBWebhookType';
@@ -89,4 +90,8 @@ export default async (req: Request) => {
   }
 
   console.log('=== END Deploy Background Function ===');
+};
+
+export const config: Config = {
+  path: '/api/handle-deploy',
 };

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -95,6 +95,6 @@ export default async (req: Request) => {
   console.log('=== END Deploy Background Function ===');
 };
 
-export const config: Config = {
-  path: '/api/handle-deploy',
-};
+// export const config: Config = {
+//   path: '/api/handle-deploy',
+// };

--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -18,7 +18,7 @@ export default async (req: Request) => {
       throw new Error('No signature');
     }
 
-    if (signature !== process.env.SECRET) {
+    if (signature !== process.env.STORYBLOK_WEBHOOK_SECRET) {
       throw new Error('Wrong signature');
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "@babel/plugin-transform-runtime": "^7.23.4",
         "@babel/preset-env": "^7.23.5",
         "@babel/preset-react": "^7.23.3",
+        "@netlify/functions": "^2.7.0",
         "@tailwindcss/forms": "^0.5.7",
         "autoprefixer": "^10.4.16",
         "axios-mock-adapter": "^1.22.0",
@@ -3608,6 +3609,45 @@
         "win32"
       ]
     },
+    "node_modules/@netlify/functions": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.7.0.tgz",
+      "integrity": "sha512-4pXC/fuj3eGQ86wbgPiM4zY8+AsNrdz6vcv6FEdUJnZW+LqF8IWjQcY3S0d1hLeLKODYOqq4CkrzGyCpce63Nw==",
+      "dev": true,
+      "dependencies": {
+        "@netlify/serverless-functions-api": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@netlify/node-cookies": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/node-cookies/-/node-cookies-0.1.0.tgz",
+      "integrity": "sha512-OAs1xG+FfLX0LoRASpqzVntVV/RpYkgpI0VrUnw2u0Q1qiZUzcPffxRK8HF3gc4GjuhG5ahOEMJ9bswBiZPq0g==",
+      "dev": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/serverless-functions-api": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.18.1.tgz",
+      "integrity": "sha512-DrSvivchuwsuQW03zbVPT3nxCQa5tn7m4aoPOsQKibuJXIuSbfxzCBxPLz0+LchU5ds7YyOaCc9872Y32ngYzg==",
+      "dev": true,
+      "dependencies": {
+        "@netlify/node-cookies": "^0.1.0",
+        "@opentelemetry/core": "^1.23.0",
+        "@opentelemetry/otlp-transformer": "^0.50.0",
+        "@opentelemetry/resources": "^1.23.0",
+        "@opentelemetry/sdk-trace-base": "^1.23.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0",
+        "urlpattern-polyfill": "8.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3646,6 +3686,275 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
+      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.1.tgz",
+      "integrity": "sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@parcel/bundler-default": {
@@ -47386,6 +47695,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true
+    },
     "node_modules/use-query-params": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-1.2.3.tgz",
@@ -50700,6 +51015,36 @@
       "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
       "optional": true
     },
+    "@netlify/functions": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-2.7.0.tgz",
+      "integrity": "sha512-4pXC/fuj3eGQ86wbgPiM4zY8+AsNrdz6vcv6FEdUJnZW+LqF8IWjQcY3S0d1hLeLKODYOqq4CkrzGyCpce63Nw==",
+      "dev": true,
+      "requires": {
+        "@netlify/serverless-functions-api": "1.18.1"
+      }
+    },
+    "@netlify/node-cookies": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/node-cookies/-/node-cookies-0.1.0.tgz",
+      "integrity": "sha512-OAs1xG+FfLX0LoRASpqzVntVV/RpYkgpI0VrUnw2u0Q1qiZUzcPffxRK8HF3gc4GjuhG5ahOEMJ9bswBiZPq0g==",
+      "dev": true
+    },
+    "@netlify/serverless-functions-api": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.18.1.tgz",
+      "integrity": "sha512-DrSvivchuwsuQW03zbVPT3nxCQa5tn7m4aoPOsQKibuJXIuSbfxzCBxPLz0+LchU5ds7YyOaCc9872Y32ngYzg==",
+      "dev": true,
+      "requires": {
+        "@netlify/node-cookies": "^0.1.0",
+        "@opentelemetry/core": "^1.23.0",
+        "@opentelemetry/otlp-transformer": "^0.50.0",
+        "@opentelemetry/resources": "^1.23.0",
+        "@opentelemetry/sdk-trace-base": "^1.23.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0",
+        "urlpattern-polyfill": "8.0.2"
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -50730,6 +51075,184 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "dev": true
+    },
+    "@opentelemetry/api-logs": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "@opentelemetry/core": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      }
+    },
+    "@opentelemetry/otlp-transformer": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+          "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.23.0",
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+          "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.23.0",
+            "@opentelemetry/resources": "1.23.0",
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+          "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+          "dev": true
+        }
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
+      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      }
+    },
+    "@opentelemetry/sdk-logs": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+          "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.23.0",
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+          "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+          "dev": true
+        }
+      }
+    },
+    "@opentelemetry/sdk-metrics": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+          "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+          "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.23.0",
+            "@opentelemetry/semantic-conventions": "1.23.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+          "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+          "dev": true
+        }
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.1.tgz",
+      "integrity": "sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
+      "dev": true
     },
     "@parcel/bundler-default": {
       "version": "2.6.2",
@@ -83004,6 +83527,12 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true
     },
     "use-query-params": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@babel/plugin-transform-runtime": "^7.23.4",
     "@babel/preset-env": "^7.23.5",
     "@babel/preset-react": "^7.23.3",
+    "@netlify/functions": "^2.7.0",
     "@tailwindcss/forms": "^0.5.7",
     "autoprefixer": "^10.4.16",
     "axios-mock-adapter": "^1.22.0",

--- a/src/types/storyblok/api/SBWebhookType.ts
+++ b/src/types/storyblok/api/SBWebhookType.ts
@@ -1,0 +1,31 @@
+export type SBPublishedPayload = {
+  text: string;
+  action: 'published';
+  space_id: number;
+  story_id: number;
+  full_slug: string;
+};
+
+export type SBUnpublishedPayload = {
+  text: string;
+  action: 'unpublished';
+  space_id: number;
+  story_id: number;
+  full_slug: string;
+};
+
+export type SBReleaseMergedPayload = {
+  text: string;
+  action: 'merged';
+  space_id: number;
+  release_id: number;
+}
+
+export type SBDatasourceUpdatedPayload = {
+  text: string;
+  action: 'entries_updated';
+  space_id: number;
+  datasource_slug: string;
+}
+
+export type SBWebhookPayload = SBPublishedPayload | SBUnpublishedPayload | SBReleaseMergedPayload | SBDatasourceUpdatedPayload;

--- a/src/types/storyblok/api/SBWebhookType.ts
+++ b/src/types/storyblok/api/SBWebhookType.ts
@@ -1,4 +1,4 @@
-export type SBPublishedPayload = {
+export type SBStoryPublishedPayload = {
   text: string;
   action: 'published';
   space_id: number;
@@ -6,12 +6,19 @@ export type SBPublishedPayload = {
   full_slug: string;
 };
 
-export type SBUnpublishedPayload = {
+export type SBStoryUnpublishedPayload = {
   text: string;
   action: 'unpublished';
   space_id: number;
   story_id: number;
   full_slug: string;
+};
+
+export type SBStoryDeletedPayload = {
+  text: string;
+  action: 'deleted';
+  space_id: number;
+  story_id: number;
 };
 
 export type SBReleaseMergedPayload = {
@@ -28,4 +35,8 @@ export type SBDatasourceUpdatedPayload = {
   datasource_slug: string;
 }
 
-export type SBWebhookPayload = SBPublishedPayload | SBUnpublishedPayload | SBReleaseMergedPayload | SBDatasourceUpdatedPayload;
+export type SBWebhookPayload = SBStoryPublishedPayload
+  | SBStoryUnpublishedPayload
+  | SBStoryDeletedPayload
+  | SBReleaseMergedPayload
+  | SBDatasourceUpdatedPayload;

--- a/src/utilities/mergeEventOverrides.js
+++ b/src/utilities/mergeEventOverrides.js
@@ -1,0 +1,57 @@
+const isString = (val) => typeof val === 'string';
+
+const isLink = (val) =>
+  typeof val === 'object' && !!Object.getOwnPropertyDescriptor(val, 'linktype');
+
+const isWysiwyg = (val) =>
+  typeof val === 'object' &&
+  !!Object.getOwnPropertyDescriptor(val, 'type') &&
+  val.type === 'doc';
+
+const isArray = (val) => Array.isArray(val);
+
+const hasOverrideValue = (val) => {
+  if (isString(val)) {
+    return !!val;
+  }
+
+  if (isArray(val)) {
+    return !!val.length;
+  }
+
+  if (isLink(val)) {
+    return !!val?.url;
+  }
+
+  if (isWysiwyg(val)) {
+    return !!val?.content[0]?.content;
+  }
+
+  return false;
+};
+
+export const mergeEventOverrides = (eventContent) => {
+  const merged = { ...eventContent };
+
+  const overrides = Object.entries(eventContent).filter(([key]) =>
+    key.endsWith('Override')
+  );
+
+  overrides.forEach(([key, val]) => {
+    // Delete override key
+    delete merged[key];
+
+    if (!val) {
+      return;
+    }
+
+    // Get non-override key
+    const nonOverrideKey = key.slice(0, -8);
+
+    if (hasOverrideValue(val)) {
+      merged[nonOverrideKey] = val;
+    }
+  });
+
+  return merged;
+};


### PR DESCRIPTION
# READY FOR REVIEW

Note: Merging this up to dev/main since it will fully replace the existing legacy webhooks in Storyblok.

# Summary
- Create new background function to handle Storyblok webhook events (everything that the current legacy webhooks do + event story handling: pub, unpub, delete, etc.)

# Review By (Date)
- End of sprint

# Criticality
- Low

# Review Tasks

## Setup tasks and/or behavior to test

1. Open this [deploy preview's function logs in Netlify](https://app.netlify.com/sites/stanford-alumni/logs/functions/handle-deploy-background?scope=deploypreview:851)
2. Trigger any/all of the following events in the Dev space in Storyblok: 
    - publish synchronized event (upserts to the dev Algolia index)
    - unpublish synchronized event (deletes from dev algolia index)
    - publish other story (triggers Netlify deploy of the Events Discovery branch)
    - unpublish other story (triggers Netlify deploy of the Events Discovery branch)
    - save a datasource entry (triggers Netlify deploy of the Events Discovery branch)
3. Verify that any published/unpublished synchronized events are reflected in the dev alumni events index in Algolia

Note (mostly to myself): I've temporarily hooked up the Storyblok Alumni Dev space to send the new webhook triggers to this deploy preview's background function (in addition to triggering the existing legacy webhooks). I've also set up this deploy preview to use dev/event discovery branch secrets. These all need to be reverted prior to merge.

# Associated Issues and/or People
- DS-683
- DS-692
- DS-693
