### PR TITLE
DS-662: Add Mega Menu option to sub pages on Alumni Homesite

### DIFF
--- a/src/components/navigation/MegaMenu/megaMenu.js
+++ b/src/components/navigation/MegaMenu/megaMenu.js
@@ -50,7 +50,7 @@ const MegaMenu = ({ blok: { topLevelLinks }, blok, className }) => {
         className={dcnb('main-nav-desktop su-hidden lg:su-block', className)}
         aria-label="Main Navigation Menu"
       >
-        <ul className="su-hidden lg:su-flex su-flex-col lg:su-ml-auto lg:su-flex-row lg:su-items-end su-list-unstyled children:su-mb-0">
+        <ul className="su-hidden lg:su-flex su-flex-col lg:su-ml-auto lg:su-flex-row lg:su-items-end lg:su-justify-end su-list-unstyled children:su-mb-0">
           <CreateBloks blokSection={topLevelLinks} />
         </ul>
       </nav>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This PR just adds `justify-end` class to mega menu component 

# Review By (Date)
- End of sprint

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Open `test-furkan-travel-study-homepage` in Storyblok and make sure that mega menu component works as expected
3. Open `/travel-study/global-components/global-header/default-travel-study-global-header-test-furkan` and make sure that mega menu component can be configured as expected and works as expected
4. Make sure that `globalHeader` block has the option to select `saaMainNav` or `megaMenu` and works as expected for both of the menu options.
