### PR TITLE
NO-JIRA: Add UNIX time to Algolia for Sync Events

### DIFF
--- a/netlify/functions/handle-deploy-background.ts
+++ b/netlify/functions/handle-deploy-background.ts
@@ -83,11 +83,28 @@ export default async (req: Request) => {
     const storyId = story.data.story.uuid;
     const eventData = story.data.story.content;
 
+    // Function to add Unix timestamps
+    const addUnixTimestamps = (eventData) => {
+      if (eventData.start) {
+        const startDate = new Date(`${eventData.start}Z`); // Ensure the date is treated as UTC
+        eventData.startUnix = Math.floor(startDate.getTime() / 1000); // Unix timestamp in seconds
+      }
+      if (eventData.end) {
+        const endDate = new Date(`${eventData.end}Z`); // Ensure the date is treated as UTC
+        eventData.endUnix = Math.floor(endDate.getTime() / 1000); // Unix timestamp in seconds
+      }
+      return eventData;
+    };
+
+    const updatedEventData = addUnixTimestamps(mergeEventOverrides(eventData));
+
+
     if (data.action === 'published') {
       // Upsert to Algolia (no rebuild)
       await index.saveObject({
         objectID: storyId,
-        ...mergeEventOverrides(eventData),
+        //...mergeEventOverrides(eventData),
+        ...updatedEventData,
       })
       console.log('Algolia upsert: ', storyId);
       console.log('=== END Deploy Background Function ===');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add UNIX start - end times to Algolia for sync events

# Review By (Date)
- ASAP

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. I temporarily setup the env variables for the PR #857 in Netlify. You can test the function changes using it.


I'll remove the temp configs after we merge this to `dev`
