### PR TITLE
Bug: False matching of active URLs.

### DIFF
--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -44,7 +44,9 @@ const MegaMenuPanel = ({
 
   if (isBrowser) {
     const { origin, pathname, hash } = window.location;
-    const browserUrl = new URL(pathname + hash, origin);
+    const browserUrl = new URL(pathname.replace(/\/+$/, '') + hash, origin);
+
+    console.log(browserUrl.toString());
 
     // Loop through children menu items and add active styles to parent button if any children items are active
     for (let i = 0; i < linkGroups.length; i += 1) {
@@ -52,7 +54,9 @@ const MegaMenuPanel = ({
         for (let j = 0; j < linkGroups[i].links.length; j += 1) {
           if (linkGroups[i].links[j].link?.cached_url) {
             const { link } = linkGroups[i].links[j];
-            const cachedUrl = new URL(link.cached_url, origin);
+            // Create a new URL object from the cached_url with stripped trailing slashes
+            const stripped = link.cached_url.replace(/\/+$/, '');
+            const cachedUrl = new URL(stripped, origin);
             if (link.anchor) {
               cachedUrl.hash = link.anchor;
             }
@@ -65,7 +69,8 @@ const MegaMenuPanel = ({
       if (linkGroups[i].secondaryLink?.cached_url) {
         if (linkGroups[i].secondaryLink.cached_url) {
           const link = linkGroups[i].secondaryLink;
-          const cachedUrl = new URL(link.cached_url, origin);
+          const stripped = link.cached_url.replace(/\/+$/, '');
+          const cachedUrl = new URL(stripped, origin);
           if (link.anchor) {
             cachedUrl.hash = link.anchor;
           }

--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -10,6 +10,7 @@ import * as styles from './megaMenuPanel.styles';
 import useOnClickOutside from '../../../hooks/useOnClickOutside';
 import { Grid } from '../../layout/Grid';
 import { GridCell } from '../../layout/GridCell';
+import { link } from '../MainNav/userNavItems.styles';
 
 const MegaMenuPanel = ({
   blok: { parentText, parentTextSecond, linkGroups, sectionCtaLink, fourthCol },
@@ -46,23 +47,29 @@ const MegaMenuPanel = ({
   if (isBrowser) {
     const browserUrl = window.location.pathname;
 
-    // Loop through children menu items and add active styles to parent button if any childrem items are active
+    // Loop through children menu items and add active styles to parent button if any children items are active
     for (let i = 0; i < linkGroups.length; i += 1) {
       if (Object.keys(linkGroups[i]).includes('links')) {
         for (let j = 0; j < linkGroups[i].links.length; j += 1) {
-          if (
-            linkGroups[i].links[j].link?.cached_url &&
-            browserUrl.includes(linkGroups[i].links[j].link.cached_url)
-          ) {
-            isActiveButton = true;
+          if (linkGroups[i].links[j].link?.cached_url) {
+            // Remove trailing and leading slashes from the URL.
+            const cachedUrl = linkGroups[i].links[j].link.cached_url.replace(/^\/|\/$/g, '');
+            const browserUrlNoSlash = browserUrl.replace(/^\/|\/$/g, '');
+            if (cachedUrl === browserUrlNoSlash) {
+              isActiveButton = true;
+            }
           }
         }
       }
-      if (
-        linkGroups[i].secondaryLink?.cached_url &&
-        browserUrl.includes(linkGroups[i].secondaryLink.cached_url)
-      ) {
-        isActiveButton = true;
+      if (linkGroups[i].secondaryLink?.cached_url) {
+        if (linkGroups[i].secondaryLink.cached_url) {
+          // Remove trailing and leading slashes from the URL.
+          const cachedUrl = linkGroups[i].secondaryLink.cached_url.replace(/^\/|\/$/g, '');
+          const browserUrlNoSlash = browserUrl.replace(/^\/|\/$/g, '');
+          if (cachedUrl === browserUrlNoSlash) {
+            isActiveButton = true;
+          }
+        }
       }
     }
   }

--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -3,7 +3,6 @@ import { ChevronDownIcon } from '@heroicons/react/outline';
 import SbEditable from 'storyblok-react';
 import CreateBloks from '../../../utilities/createBloks';
 import useEscape from '../../../hooks/useEscape';
-import { Container } from '../../layout/Container';
 import { isExpanded, isBrowser } from '../../../utilities/menuHelpers';
 import { ModalContext } from '../../layout/Modal/ModalContext';
 import * as styles from './megaMenuPanel.styles';
@@ -52,7 +51,10 @@ const MegaMenuPanel = ({
         for (let j = 0; j < linkGroups[i].links.length; j += 1) {
           if (linkGroups[i].links[j].link?.cached_url) {
             // Remove trailing and leading slashes from the URL.
-            const cachedUrl = linkGroups[i].links[j].link.cached_url.replace(/^\/|\/$/g, '');
+            const cachedUrl = linkGroups[i].links[j].link.cached_url.replace(
+              /^\/|\/$/g,
+              ''
+            );
             const browserUrlNoSlash = browserUrl.replace(/^\/|\/$/g, '');
             if (cachedUrl === browserUrlNoSlash) {
               isActiveButton = true;
@@ -63,7 +65,10 @@ const MegaMenuPanel = ({
       if (linkGroups[i].secondaryLink?.cached_url) {
         if (linkGroups[i].secondaryLink.cached_url) {
           // Remove trailing and leading slashes from the URL.
-          const cachedUrl = linkGroups[i].secondaryLink.cached_url.replace(/^\/|\/$/g, '');
+          const cachedUrl = linkGroups[i].secondaryLink.cached_url.replace(
+            /^\/|\/$/g,
+            ''
+          );
           const browserUrlNoSlash = browserUrl.replace(/^\/|\/$/g, '');
           if (cachedUrl === browserUrlNoSlash) {
             isActiveButton = true;

--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -43,20 +43,20 @@ const MegaMenuPanel = ({
   let isActiveButton;
 
   if (isBrowser) {
-    const browserUrl = window.location.pathname;
+    const { origin, pathname, hash } = window.location;
+    const browserUrl = new URL(pathname + hash, origin);
 
     // Loop through children menu items and add active styles to parent button if any children items are active
     for (let i = 0; i < linkGroups.length; i += 1) {
       if (Object.keys(linkGroups[i]).includes('links')) {
         for (let j = 0; j < linkGroups[i].links.length; j += 1) {
           if (linkGroups[i].links[j].link?.cached_url) {
-            // Remove trailing and leading slashes from the URL.
-            const cachedUrl = linkGroups[i].links[j].link.cached_url.replace(
-              /^\/|\/$/g,
-              ''
-            );
-            const browserUrlNoSlash = browserUrl.replace(/^\/|\/$/g, '');
-            if (cachedUrl === browserUrlNoSlash) {
+            const { link } = linkGroups[i].links[j];
+            const cachedUrl = new URL(link.cached_url, origin);
+            if (link.anchor) {
+              cachedUrl.hash = link.anchor;
+            }
+            if (cachedUrl.toString() === browserUrl.toString()) {
               isActiveButton = true;
             }
           }
@@ -64,13 +64,12 @@ const MegaMenuPanel = ({
       }
       if (linkGroups[i].secondaryLink?.cached_url) {
         if (linkGroups[i].secondaryLink.cached_url) {
-          // Remove trailing and leading slashes from the URL.
-          const cachedUrl = linkGroups[i].secondaryLink.cached_url.replace(
-            /^\/|\/$/g,
-            ''
-          );
-          const browserUrlNoSlash = browserUrl.replace(/^\/|\/$/g, '');
-          if (cachedUrl === browserUrlNoSlash) {
+          const link = linkGroups[i].secondaryLink;
+          const cachedUrl = new URL(link.cached_url, origin);
+          if (link.anchor) {
+            cachedUrl.hash = link.anchor;
+          }
+          if (cachedUrl.toString() === browserUrl.toString()) {
             isActiveButton = true;
           }
         }

--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -46,8 +46,6 @@ const MegaMenuPanel = ({
     const { origin, pathname, hash } = window.location;
     const browserUrl = new URL(pathname.replace(/\/+$/, '') + hash, origin);
 
-    console.log(browserUrl.toString());
-
     // Loop through children menu items and add active styles to parent button if any children items are active
     for (let i = 0; i < linkGroups.length; i += 1) {
       if (Object.keys(linkGroups[i]).includes('links')) {

--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -40,12 +40,11 @@ const MegaMenuPanel = ({
 
   useOnClickOutside(ref, () => setPanelOpened(false));
 
-  let isActiveButton;
+  let isActiveButton = false;
 
   if (isBrowser) {
     const { origin, pathname, hash } = window.location;
     const browserUrl = new URL(pathname.replace(/\/+$/, '') + hash, origin);
-
     // Loop through children menu items and add active styles to parent button if any children items are active
     for (let i = 0; i < linkGroups.length; i += 1) {
       if (Object.keys(linkGroups[i]).includes('links')) {
@@ -58,6 +57,7 @@ const MegaMenuPanel = ({
             if (link.anchor) {
               cachedUrl.hash = link.anchor;
             }
+
             if (cachedUrl.toString() === browserUrl.toString()) {
               isActiveButton = true;
             }
@@ -69,6 +69,37 @@ const MegaMenuPanel = ({
           const link = linkGroups[i].secondaryLink;
           const stripped = link.cached_url.replace(/\/+$/, '');
           const cachedUrl = new URL(stripped, origin);
+          if (link.anchor) {
+            cachedUrl.hash = link.anchor;
+          }
+          if (cachedUrl.toString() === browserUrl.toString()) {
+            isActiveButton = true;
+          }
+        }
+      }
+    }
+    // Check the fourth column for active links
+    if (fourthCol && fourthCol.length > 0) {
+      const fourthComponent = fourthCol[0];
+      if (fourthComponent.component === 'megaMenuLinkGroup') {
+        const { links, secondaryLink } = fourthComponent;
+        for (let j = 0; j < links.length; j += 1) {
+          if (links[j].link?.cached_url) {
+            const { link } = links[j];
+            const stripped = link.cached_url.replace(/\/+$/, '');
+            const cachedUrl = new URL(stripped, window.location.origin);
+            if (link.anchor) {
+              cachedUrl.hash = link.anchor;
+            }
+            if (cachedUrl.toString() === browserUrl.toString()) {
+              isActiveButton = true;
+            }
+          }
+        }
+        if (secondaryLink?.cached_url) {
+          const link = secondaryLink;
+          const stripped = link.cached_url.replace(/\/+$/, '');
+          const cachedUrl = new URL(stripped, window.location.origin);
           if (link.anchor) {
             cachedUrl.hash = link.anchor;
           }

--- a/src/components/navigation/MegaMenu/megaMenuPanel.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.js
@@ -10,7 +10,6 @@ import * as styles from './megaMenuPanel.styles';
 import useOnClickOutside from '../../../hooks/useOnClickOutside';
 import { Grid } from '../../layout/Grid';
 import { GridCell } from '../../layout/GridCell';
-import { link } from '../MainNav/userNavItems.styles';
 
 const MegaMenuPanel = ({
   blok: { parentText, parentTextSecond, linkGroups, sectionCtaLink, fourthCol },

--- a/src/components/navigation/MegaMenu/megaMenuPanel.styles.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.styles.js
@@ -20,7 +20,7 @@ export const parentButton = ({ panelOpened, isActiveButton } = {}) =>
     {
       '!su-bg-white !su-border-cardinal-red-xdark lg:hover:!su-bg-transparent !su-text-digital-red-light su-border-b !su-border-black-20 lg:!su-bg-transparent lg:!su-border-digital-red-light':
         panelOpened,
-      'su-bg-white lg:!su-text-digital-red-xlight lg:su-bg-transparent lg:!su-border-digital-red-xlight':
+      'su-bg-white lg:!su-text-digital-red-xlight lg:su-bg-transparent lg:!su-border-digital-red-xlight active-button':
         isActiveButton,
     }
   );

--- a/src/components/navigation/MegaMenu/megaMenuPanel.styles.js
+++ b/src/components/navigation/MegaMenu/megaMenuPanel.styles.js
@@ -20,7 +20,7 @@ export const parentButton = ({ panelOpened, isActiveButton } = {}) =>
     {
       '!su-bg-white !su-border-cardinal-red-xdark lg:hover:!su-bg-transparent !su-text-digital-red-light su-border-b !su-border-black-20 lg:!su-bg-transparent lg:!su-border-digital-red-light':
         panelOpened,
-      'su-bg-white lg:!su-text-digital-red-xlight lg:su-bg-transparent lg:!su-border-digital-red-xlight active-button':
+      'su-bg-white lg:!su-text-digital-red-xlight lg:su-bg-transparent lg:!su-border-digital-red-xlight':
         isActiveButton,
     }
   );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Does exact string matching instead of partial for setting active links in the mega menu

# Review By (Date)
- EOW (Aug 2)

# Criticality
- Normal

# Review Tasks

1. Navigate to https://alumni.stanford.edu/career-connections/students
2. See the mega menu top level links light up for more than one section
3. This is due to the nav items with the url string `students` matching in `/career-connections/students`
4. Navigate to the [preview build](https://deploy-preview-897--stanford-alumni.netlify.app/career-connections/students)
5. Validate that only one mega menu top level is highlighted

