### PR TITLE
DS-735 | @ericbakenhus | Stretch link for event cards

### DIFF
--- a/src/components/content-types/synchronized-event/SynchronizedEventCard.jsx
+++ b/src/components/content-types/synchronized-event/SynchronizedEventCard.jsx
@@ -79,6 +79,7 @@ export const SynchronizedEventCard = ({
           title={title || 'Untitled'}
           eventUrl={eventUrl}
           headingLevel={headingLevel}
+          stretchLink
         />
         <EventContent
           start={luxonStart}
@@ -89,6 +90,7 @@ export const SynchronizedEventCard = ({
           region={region}
           subject={subject}
           subjectHeadingLevel={headingLevel + 1}
+          localTimezoneOnly
         />
       </div>
     </div>

--- a/src/components/events-discovery/components/Event/EventContent.jsx
+++ b/src/components/events-discovery/components/Event/EventContent.jsx
@@ -21,6 +21,7 @@ import { Heading } from '../../../simple/Heading';
  * @property {string} [region]
  * @property {string[]} [subject]
  * @property {number} [subjectHeadingLevel]
+ * @property {boolean} [localTimezoneOnly]
  */
 
 /**
@@ -37,6 +38,7 @@ export const EventContent = ({
   region = '',
   subject = [],
   subjectHeadingLevel = 4,
+  localTimezoneOnly = false,
 }) => {
   const uniqueId = useId();
   const eventTimezone = rawEventTimezone || 'America/Los_Angeles';
@@ -57,8 +59,8 @@ export const EventContent = ({
   } = eventTime;
 
   const isEventLocal = useMemo(
-    () => eventTimezoneDisplay === localTimezoneDisplay,
-    [eventTimezoneDisplay, localTimezoneDisplay]
+    () => localTimezoneOnly || eventTimezoneDisplay === localTimezoneDisplay,
+    [localTimezoneOnly, eventTimezoneDisplay, localTimezoneDisplay]
   );
 
   const isOffsetSame = useMemo(


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Stretches the event card link over the entire card

# Review By (Date)
- Soon-ish/retro

# Criticality
- Medium

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to [/test-eric/test-basic/](https://deploy-preview-959--stanford-alumni.netlify.app/test-eric/test-basic/)
3. Verify that each card's link covers the entire card
4. Verify that there are no time zone selects on any card

# Associated Issues and/or People
- DS-735
