### PR TITLE
Nojira | @ericbakenhus | Scroll to heading on event pagination change

### DIFF
--- a/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
+++ b/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
@@ -7,7 +7,7 @@ export const NoResultsComponent = () => (
       <div className="su-text-center">
         <h2
           id="event-search-count-heading"
-          className="su-text-center su-text-cardinal-red-light"
+          className="su-text-center su-text-cardinal-red-light su-scroll-mt-16"
         >
           No events found!
         </h2>

--- a/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
+++ b/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
@@ -5,7 +5,10 @@ export const NoResultsComponent = () => (
   <div className="su-w-full su-flex su-items-center su-justify-center">
     <div className="su-flex su-justify-center su-items-center su-rs-my-2">
       <div className="su-text-center">
-        <h2 className="su-text-center su-text-cardinal-red-light">
+        <h2
+          id="event-search-count-heading"
+          className="su-text-center su-text-cardinal-red-light"
+        >
           No events found!
         </h2>
         <p className="su-text-center">

--- a/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
+++ b/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
@@ -5,11 +5,7 @@ export const NoResultsComponent = () => (
   <div className="su-w-full su-flex su-items-center su-justify-center">
     <div className="su-flex su-justify-center su-items-center su-rs-my-2">
       <div className="su-text-center">
-        <h2
-          id="event-search-count-heading"
-          className="su-text-center su-text-cardinal-red-light su-scroll-mt-16"
-          tabIndex={-1}
-        >
+        <h2 className="su-text-center su-text-cardinal-red-light">
           No events found!
         </h2>
         <p className="su-text-center">

--- a/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
+++ b/src/components/events-discovery/components/NoResults/NoResultsComponent.jsx
@@ -8,6 +8,7 @@ export const NoResultsComponent = () => (
         <h2
           id="event-search-count-heading"
           className="su-text-center su-text-cardinal-red-light su-scroll-mt-16"
+          tabIndex={-1}
         >
           No events found!
         </h2>

--- a/src/components/events-discovery/components/Pagination/Pagination.jsx
+++ b/src/components/events-discovery/components/Pagination/Pagination.jsx
@@ -21,17 +21,18 @@ export const Pagination = (props) => {
   const scrollToHeading = useCallback(() => {
     const reduceMotion = !!window.matchMedia('(prefers-reduced-motion: reduce)')
       ?.matches;
-    const heading = document.getElementById('event-search-count-heading');
 
-    if (heading) {
-      setTimeout(() => {
+    setTimeout(() => {
+      const heading = document.getElementById('event-search-count-heading');
+
+      if (heading) {
         heading.focus({ preventScroll: true });
         heading.scrollIntoView({
           block: 'start',
           behavior: reduceMotion ? 'instant' : 'smooth',
         });
-      }, 150);
-    }
+      }
+    }, 150);
   }, []);
 
   const handlePageSelect = useCallback(

--- a/src/components/events-discovery/components/Pagination/Pagination.jsx
+++ b/src/components/events-discovery/components/Pagination/Pagination.jsx
@@ -24,8 +24,13 @@ export const Pagination = (props) => {
     const heading = document.getElementById('event-search-count-heading');
 
     if (heading) {
-      heading.scrollIntoView({ behavior: reduceMotion ? 'instant' : 'smooth' });
-      heading.focus({ preventScroll: true });
+      setTimeout(() => {
+        heading.focus({ preventScroll: true });
+        heading.scrollIntoView({
+          block: 'start',
+          behavior: reduceMotion ? 'instant' : 'smooth',
+        });
+      }, 150);
     }
   }, []);
 

--- a/src/components/events-discovery/components/Pagination/Pagination.jsx
+++ b/src/components/events-discovery/components/Pagination/Pagination.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { dcnb } from 'cnbuilder';
 // eslint-disable-next-line no-unused-vars
 import { usePagination, UsePaginationProps } from 'react-instantsearch';
@@ -17,6 +17,25 @@ export const Pagination = (props) => {
     refine,
     createURL,
   } = usePagination(props);
+
+  const scrollToHeading = useCallback(() => {
+    const reduceMotion = !!window.matchMedia('(prefers-reduced-motion: reduce)')
+      ?.matches;
+    const heading = document.getElementById('event-search-count-heading');
+
+    if (heading) {
+      heading.scrollIntoView({ behavior: reduceMotion ? 'instant' : 'smooth' });
+      heading.focus({ preventScroll: true });
+    }
+  }, []);
+
+  const handlePageSelect = useCallback(
+    (nextPage) => {
+      refine(nextPage);
+      scrollToHeading();
+    },
+    [refine, scrollToHeading]
+  );
 
   if (!canRefine) {
     return null;
@@ -52,7 +71,7 @@ export const Pagination = (props) => {
             href={createURL(currentRefinement - 1)}
             onClick={(e) => {
               e.preventDefault();
-              refine(currentRefinement - 1);
+              handlePageSelect(currentRefinement - 1);
             }}
             aria-label="Previous page"
             className={directionCta({ isShown: !isFirstPage })}
@@ -67,7 +86,7 @@ export const Pagination = (props) => {
               href={createURL(page)}
               onClick={(e) => {
                 e.preventDefault();
-                refine(page);
+                handlePageSelect(page);
               }}
               aria-label={
                 isLastPage ? `Last page, page ${page + 1}` : `Page ${page + 1}`
@@ -85,7 +104,7 @@ export const Pagination = (props) => {
             href={createURL(currentRefinement + 1)}
             onClick={(e) => {
               e.preventDefault();
-              refine(currentRefinement + 1);
+              handlePageSelect(currentRefinement + 1);
             }}
             aria-label="Next page"
             className={directionCta({ isShown: !isLastPage })}

--- a/src/components/events-discovery/components/StatusHeader/StatusHeader.jsx
+++ b/src/components/events-discovery/components/StatusHeader/StatusHeader.jsx
@@ -53,6 +53,7 @@ export const StatusHeader = () => {
 
   return (
     <h2
+      id="event-search-count-heading"
       aria-live="polite"
       aria-atomic="true"
       className="su-text-black-80 su-text-20 su-font-normal"

--- a/src/components/events-discovery/components/StatusHeader/StatusHeader.jsx
+++ b/src/components/events-discovery/components/StatusHeader/StatusHeader.jsx
@@ -56,7 +56,7 @@ export const StatusHeader = () => {
       id="event-search-count-heading"
       aria-live="polite"
       aria-atomic="true"
-      className="su-text-black-80 su-text-20 su-font-normal"
+      className="su-text-black-80 su-text-20 su-font-normal su-scroll-mt-16"
     >
       {countDisplay}
       <span className="su-sr-only">{pageDisplay}</span>

--- a/src/components/events-discovery/components/StatusHeader/StatusHeader.jsx
+++ b/src/components/events-discovery/components/StatusHeader/StatusHeader.jsx
@@ -57,6 +57,7 @@ export const StatusHeader = () => {
       aria-live="polite"
       aria-atomic="true"
       className="su-text-black-80 su-text-20 su-font-normal su-scroll-mt-16"
+      tabIndex={-1}
     >
       {countDisplay}
       <span className="su-sr-only">{pageDisplay}</span>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Scroll to top of results when paging though events

# Review By (Date)
- Now/retro

# Criticality
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to /events/discovery
3. Click through the pagination nav
4. Verify you are scrolled to the top of the results
5. Verify focus is moved to the results heading (results count)