### PR TITLE
Nojira | @ericbakenhus | Remove draft versions of published events

### DIFF
--- a/netlify/functions/event-import-background.mts
+++ b/netlify/functions/event-import-background.mts
@@ -70,7 +70,7 @@ export default async (req: Request) => {
     const hivebriteSheet = hivebriteDoc.sheetsByIndex[0];
     const hivebriteRows = await hivebriteSheet.getRows();
     console.log(`Fetching Hiverbrite data done! (${hivebriteRows?.length ?? 0} found)`);
-    
+
     hivebriteRows.forEach((row) => {
       googleStories.push(googleRowToStory(row.toObject(), 'hivebrite'));
     });
@@ -81,7 +81,7 @@ export default async (req: Request) => {
     const cventSheet = cventDoc.sheetsByIndex[0];
     const cventRows = await cventSheet.getRows();
     console.log(`Fetching Cvent data done! (${cventRows?.length ?? 0} found)`);
-    
+
     cventRows.forEach((row) => {
       googleStories.push(googleRowToStory(row.toObject(), 'cvent'));
     });
@@ -113,9 +113,9 @@ export default async (req: Request) => {
       version: 'published',
       per_page: 100,
     }) ?? [];
-    const sbDraftEvents = await storyblokContent.getAll('cdn/stories', { 
-      starts_with: 'events/sync/', 
-      content_type: 'synchronizedEvent', 
+    const sbDraftEvents = await storyblokContent.getAll('cdn/stories', {
+      starts_with: 'events/sync/',
+      content_type: 'synchronizedEvent',
       version: 'draft',
       per_page: 100,
     }) ?? [];
@@ -386,9 +386,9 @@ export default async (req: Request) => {
 
       try {
         const isOld = luxonDate(
-          story.content.endOverride 
-          || story.content.end 
-          || story.content.startOverride 
+          story.content.endOverride
+          || story.content.end
+          || story.content.startOverride
           || story.content.start
         ) < OldCutoff;
 

--- a/netlify/functions/event-import-background.mts
+++ b/netlify/functions/event-import-background.mts
@@ -86,10 +86,6 @@ export default async (req: Request) => {
       googleStories.push(googleRowToStory(row.toObject(), 'cvent'));
     });
 
-    const storyblokContent = new StoryblokClient({
-      accessToken: process.env.STORYBLOK_WEBHOOK_PREVIEW_ACCESS_TOKEN,
-    });
-
     const storyblokManagement = new StoryblokClient({
       oauthToken: process.env.STORYBLOK_MANAGEMENT_OAUTH_TOKEN,
     });

--- a/netlify/functions/event-import-background.mts
+++ b/netlify/functions/event-import-background.mts
@@ -146,6 +146,7 @@ export default async (req: Request) => {
     console.log(`Fetching Storyblok events done! (${sbEvents?.length ?? 0} found)`);
 
     console.log({ sbPublishedEvents, sbUnpublishedEvents, filteredSbUnpublishedEvents });
+    return;
 
     const syncedEvents = new Map();
     const manualEvents = new Map();

--- a/netlify/functions/event-import-background.mts
+++ b/netlify/functions/event-import-background.mts
@@ -108,12 +108,12 @@ export default async (req: Request) => {
       story_only: true,
       is_published: true,
     }) ?? [];
-    const sbUnpublishedEvents = await storyblokManagement.getAll('/spaces/${spaceId}/stories', { 
+    const sbUnpublishedEvents = await storyblokManagement.getAll(`/spaces/${spaceId}/stories`, { 
       starts_with: 'events/sync/', 
       story_only: true,
       is_published: false,
     }) ?? [];
-    const oldArchivedEvents = await storyblokManagement.getAll('/spaces/${spaceId}/stories', { 
+    const oldArchivedEvents = await storyblokManagement.getAll(`/spaces/${spaceId}/stories`, { 
       starts_with: 'events/sync-archive/', 
       story_only: true,
       filter_query: { __or: [

--- a/netlify/functions/event-import-background.mts
+++ b/netlify/functions/event-import-background.mts
@@ -119,6 +119,7 @@ export default async (req: Request) => {
       version: 'draft',
       per_page: 100,
     }) ?? [];
+    const filteredSbUnpublishedEvents = sbUnpublishedEvents?.filter((event) => !sbPublishedEvents.some((pubEvent) => pubEvent.id === event.id));
     const oldArchivedPublishedEvents = await storyblokContent.getAll('cdn/stories', { 
       starts_with: 'events/sync-archive/', 
       filter_query: { __or: [
@@ -139,11 +140,12 @@ export default async (req: Request) => {
       version: 'draft',
       per_page: 100,
     }) ?? [];
-    const sbEvents = [...sbPublishedEvents?.map((s) => ({ ...s, isPublished: true })), ...sbUnpublishedEvents?.map((s) => ({ ...s, isPublished: false }))];
-    const oldArchivedEvents = [...oldArchivedPublishedEvents, ...oldArchivedUnpublishedEvents].filter((s) => !!s);
+    const filteredOldArchivedUnpublishedEvents = oldArchivedUnpublishedEvents?.filter((event) => !oldArchivedPublishedEvents.some((pubEvent) => pubEvent.id === event.id));
+    const sbEvents = [...sbPublishedEvents?.map((s) => ({ ...s, isPublished: true })), ...filteredSbUnpublishedEvents?.map((s) => ({ ...s, isPublished: false }))];
+    const oldArchivedEvents = [...oldArchivedPublishedEvents, ...filteredOldArchivedUnpublishedEvents].filter((s) => !!s);
     console.log(`Fetching Storyblok events done! (${sbEvents?.length ?? 0} found)`);
 
-    console.log({ sbPublishedEvents, sbUnpublishedEvents });
+    console.log({ sbPublishedEvents, sbUnpublishedEvents, filteredSbUnpublishedEvents });
 
     const syncedEvents = new Map();
     const manualEvents = new Map();


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes the draft version of any events that are published with changes (will appear in both published and draft requests)
- Splits out `isPublished` to prevent it from appearing in other systems

# Review By (Date)
- 🤷 

# Criticality
- Medium(?)

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at code
2. Maybe ping the deploy preview background function with Postman and watch the logs (feel free to set `run` to `test` in vaut if you don't want it to make changes in the dev SB space; doesn't really matter either way though)
    - https://deploy-preview-981--stanford-alumni.netlify.app/webhook/sb/event-import?secret=[secret-here]